### PR TITLE
docs: refresh README for Spectrum Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,48 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/8cfa8785-8df8-4aad-ad35-8f1c790b8baf/deploy-status)](https://app.netlify.com/sites/digital-garden-jekyll-template/deploys)
 
-# Digital garden Jekyll template
+# Spectrum Syntax
 
-Use this template repository to get started with your own digital garden.
+Spectrum Syntax is a personal digital garden built with Jekyll. It is based on Maxime Vaillancourt's [digital-garden-jekyll-template](https://github.com/maximevaillancourt/digital-garden-jekyll-template); thanks to Maxime for sharing it.
 
-**I wrote a tutorial explaining how to set it up: [Setting up your own digital garden with Jekyll](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)**
+https://spectrumsyntax.netlify.app/
 
-Preview the template here: https://digital-garden-jekyll-template.netlify.app/
+## Features
 
-- Based on Jekyll, a static website generator
-- Supports Roam-style double bracket link syntax to other notes
-- Creates backlinks to other notes automatically
-- Features link previews on hover
-- Includes graph visualization of the notes and their links
-- Features a simple and responsive design
-- Supports Markdown or HTML notes
+- Roam-style double bracket links
+- Automatic backlinks between notes
+- Hover link previews
+- Interactive notes graph
+- Simple, responsive design
+- Markdown or HTML notes
 
-<img width="1522" alt="Screen Shot 2020-05-19 at 23 05 46" src="https://user-images.githubusercontent.com/8457808/82400515-7d026d80-9a25-11ea-83f1-3b9cb8347e07.png">
+## Local setup
 
-## A note about GitHub Pages
-> [!NOTE]  
-> **Update (January 2023)**: it seems that GitHub Pages supports custom plugins now, thanks to GitHub Actions ([view relevant discussion](https://github.com/maximevaillancourt/digital-garden-jekyll-template/discussions/144)). 
+1. Install dependencies:
+   ```bash
+   bundle install
+   ```
+2. Build or serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   # or
+   bundle exec jekyll build
+   ```
+   The development server runs at http://localhost:4000.
 
-GitHub Pages only partially supports this template: to power the interactive notes graph, this template uses a custom Jekyll plugin to generate the graph data in [`notes_graph.json`](https://github.com/maximevaillancourt/digital-garden-jekyll-template/blob/7ac331a4113bac77c993856562acc2bfbde9f2f7/_plugins/bidirectional_links_generator.rb#L102), and [GitHub Pages doesn't support custom Jekyll plugins](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins).
+## Deployment
 
-If you want to use the graph with GitHub Pages, you may try building your garden locally using Jekyll then pushing the result to GitHub Pages.
+This site relies on custom Jekyll plugins, so GitHub Pages cannot build it directly. The project is deployed to Netlify using the configuration in [`netlify.toml`](netlify.toml). Pushing to the main branch triggers a production build.
 
-Alternatively, you may deploy your garden to Netlify and it'll work out of the box. [I wrote a guide explaining how to set this up](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll).
+To host the site elsewhere, run `bundle exec jekyll build` and upload the generated `_site` directory to your provider.
 
-If you don't care about the graph, you can simply remove it from this layout, [as explained here](https://github.com/maximevaillancourt/digital-garden-jekyll-template/discussions/132#discussioncomment-3625772).
+## Customization
+
+- Add or edit notes in [`_notes/`](./_notes).
+- Update pages in [`_pages/`](./_pages).
+- Adjust global settings in [`_config.yml`](_config.yml).
+- Tweak styles via `styles.scss` and the files under [`assets/`](./assets).
 
 ## License
 
 Source code is available under the [MIT license](LICENSE.md).
+


### PR DESCRIPTION
## Summary
- introduce Spectrum Syntax and credit the digital garden Jekyll template
- replace template setup text with instructions for this repository

## Testing
- `bundle install`
- `bundle exec jekyll build` *(conflict warning about duplicate :slug.md)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7fd2d9fc832689f3d048ac4b5df4