### PR TITLE
Set rel attribute for external links

### DIFF
--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -22,6 +22,7 @@ def convert_links(doc)
     parsed_doc = Nokogiri::HTML::DocumentFragment.parse(doc.content)
     parsed_doc.css("a:not(.internal-link):not(.footnote):not(.reversefootnote)").each do |link|
       link.set_attribute('target', '_blank')
+      link.set_attribute('rel', 'noopener noreferrer')
     end
     doc.content = parsed_doc.inner_html
   end


### PR DESCRIPTION
## Summary
- ensure external links opened in a new tab also use `rel="noopener noreferrer"`

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7fe5b4a083268146de86bcef90c3