### PR TITLE
Use placeholder images for missing tumble log photos

### DIFF
--- a/_notes/tumble_logs/2025-08-21-batch-001.md
+++ b/_notes/tumble_logs/2025-08-21-batch-001.md
@@ -29,17 +29,17 @@ consumables_brand: "National Geographic"
 # Milestone photos (any can be omitted)
 images:
   rough: "/assets/tumbling/001/rough.jpg"
-  cover: "/assets/tumbling/001/cover.jpg"
+  cover: "/assets/tumbling/coming_soon.jpg"
   after_stage_1: "/assets/tumbling/001/after-s1.jpg"
-  after_stage_2: "/assets/tumbling/001/after-s2.jpg"
+  after_stage_2: "/assets/tumbling/coming_soon.jpg"
   after_stage_3: "/assets/tumbling/001/after-s3.jpg"
   after_stage_4: "/assets/tumbling/001/after-s4.jpg"
-  after_burnish: "/assets/tumbling/001/after-burnish.jpg"
+  after_burnish: "/assets/tumbling/coming_soon.jpg"
   gallery:
-    - "/assets/tumbling/001/detail1.jpg"
-    - src: "/assets/tumbling/001/tray.jpg"
-      alt: "Sorting tray"
-      caption: "Size sorting before Stage 1"
+    - "/assets/tumbling/coming_soon.jpg"
+    - src: "/assets/tumbling/coming_soon.jpg"
+      alt: "Coming soon"
+      caption: "Image coming soon"
 
 # Stages (progress is auto-calculated from these where possible)
 stages:
@@ -58,10 +58,10 @@ stages:
       repeat:
       why:
     images:
-      - "/assets/tumbling/001/stage1-start.jpg"
-      - src: "/assets/tumbling/001/stage1-end.jpg"
-        alt: "Stage 1 end"
-        caption: "Edges rounding"
+      - "/assets/tumbling/coming_soon.jpg"
+      - src: "/assets/tumbling/coming_soon.jpg"
+        alt: "Coming soon"
+        caption: "Image coming soon"
 
   - stage: 2
     name: "Medium Grind"


### PR DESCRIPTION
## Summary
- replace missing Batch 001 tumble log images with placeholder image

## Testing
- `jekyll build` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ae862274388326a009a31a16da0289