### PR TITLE
feat: handle hash inputs in ensure_image

### DIFF
--- a/_plugins/image_exists_filter.rb
+++ b/_plugins/image_exists_filter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module ImageExistsFilter
+    PLACEHOLDER = '/assets/tumbling/coming_soon.jpg'
+
+    def ensure_image(input)
+      path = case input
+             when Hash
+               input['src'] || input[:src]
+             else
+               input
+             end
+
+      return PLACEHOLDER unless path.is_a?(String) && !path.empty?
+      return path if path.start_with?('http://', 'https://')
+
+      site_source = @context.registers[:site].source
+      relative = path.sub(%r{^/}, '')
+      absolute = File.expand_path(relative, site_source)
+      File.exist?(absolute) ? path : PLACEHOLDER
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ImageExistsFilter)
+


### PR DESCRIPTION
## Summary
- allow `ensure_image` filter to accept a Hash and use its `src`
- guard against non-string paths and fall back to placeholder

## Testing
- `bundle exec jekyll build`
- `bundle exec rubocop _plugins/image_exists_filter.rb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d8a11608326b66e1198cd1bd871