### PR TITLE
feat: skip existence check for remote images

### DIFF
--- a/_plugins/image_exists_filter.rb
+++ b/_plugins/image_exists_filter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Jekyll
+  # Liquid filter that verifies image paths before rendering.
+  # If the path points to a remote URL, return it unchanged.
+  # Otherwise, return the path when the file exists or a placeholder
+  # when it does not.
+  module ImageExistsFilter
+    PLACEHOLDER = '/assets/tumbling/coming_soon.jpg'
+
+    # Checks whether an image path exists on disk.
+    # @param input [String] raw path or an HTML tag containing a `src` attribute
+    # @param placeholder [String] path to use when the image is missing
+    # @return [String] either the original path or the placeholder
+    def image_exists(input, placeholder = PLACEHOLDER)
+      return placeholder if input.nil? || input.empty?
+
+      path = input.to_s
+      path = path[/src\s*=\s*['"]([^'"]+)['"]/i, 1] || path
+
+      # Skip local existence checks for remote URLs
+      return path if path.start_with?('http://', 'https://')
+
+      site_source = @context.registers[:site].source
+      normalized = path.sub(%r{^/}, '')
+      absolute = File.expand_path(normalized, site_source)
+
+      File.exist?(absolute) ? path : placeholder
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ImageExistsFilter)


### PR DESCRIPTION
## Summary
- add `image_exists` filter to skip File.exist? for HTTP(S) URLs and return placeholder for missing local images

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68ae8d8f50ec8326b033afba04db2d97