### PR TITLE
Add alt text support for extra stage images

### DIFF
--- a/_layouts/tumble.html
+++ b/_layouts/tumble.html
@@ -118,7 +118,11 @@ Helpers
       {% if imgs and imgs.size > 1 %}
         <div class="stage-gallery">
           {% for extra in imgs offset:1 %}
-            <img src="{{ extra | relative_url }}" alt="Stage {{ st.stage }} extra image {{ forloop.index }}">
+            {% if extra.alt != nil %}
+              <img src="{{ extra.src | default: extra | relative_url }}" alt="{{ extra.alt }}">
+            {% else %}
+              <img src="{{ extra | relative_url }}" alt="Stage {{ st.stage }} extra image {{ forloop.index }}">
+            {% endif %}
           {% endfor %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Render alt text when extra stage images are provided as objects
- Keep fallback text for string-based images

## Testing
- `bundle exec jekyll build`
- `ruby scripts/check_assets.rb`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d934dd48326bbc066e7d84fc716