### PR TITLE
Refactor image exists filter

### DIFF
--- a/_plugins/image_exists_filter.rb
+++ b/_plugins/image_exists_filter.rb
@@ -4,12 +4,20 @@ module Jekyll
   module ImageExistsFilter
     PLACEHOLDER = '/assets/tumbling/coming_soon.jpg'
 
-    def ensure_image(input)
+    # Returns the image path if it exists, otherwise returns a placeholder.
+    # Accepts a raw path String, an HTML tag String, or a Hash containing :src or 'src'.
+    def image_exists(input)
       path = case input
              when Hash
                input['src'] || input[:src]
+             when String
+               if input.lstrip.start_with?('<')
+                 input[/src\s*=\s*['"]([^'"]+)['"]/i, 1]
+               else
+                 input
+               end
              else
-               input
+               input.to_s
              end
 
       return PLACEHOLDER unless path.is_a?(String) && !path.empty?


### PR DESCRIPTION
## Summary
- consolidate filter into single `image_exists` method handling strings, HTML tags, and hashes
- return original path for remote URLs and placeholder for missing local images

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9413bd988326a7cf811234909f45