### PR TITLE
chore: tidy image_exists filter

### DIFF
--- a/_plugins/image_exists_filter.rb
+++ b/_plugins/image_exists_filter.rb
@@ -24,4 +24,3 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::ImageExistsFilter)
-


### PR DESCRIPTION
## Summary
- ensure frozen string literal header and clean formatting in image_exists_filter

## Testing
- `ruby -c _plugins/image_exists_filter.rb`
- `bundle install` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `curl -X POST https://api.netlify.com/build_hooks/8cfa8785-8df8-4aad-ad35-8f1c790b8baf` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae942182ec832699c6263b7dc001ad