### PR TITLE
Add explicit tumble_logs collection

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,10 +31,9 @@ collections:
   notes:
     output: true
     permalink: /:slug
-  # Remove this block if you keep tumbles under _notes
-  # tumbles:
-  #   output: true
-  #   permalink: /tumbling/:name/
+  tumble_logs:
+    output: true
+    permalink: /tumbling/:name/
 
 # --- Defaults (layouts, etc.) ---
 defaults:
@@ -53,16 +52,9 @@ defaults:
   # Tumble collection items use the 'tumble' layout
   - scope:
       path: ""
-      type: "tumbles"
+      type: "tumble_logs"
     values:
       layout: "tumble"
-  
-  # Tumbles inside _notes should publish under /tumbling/:basename/
-  - scope:
-      path: "_notes/tumble_logs"
-    values:
-      layout: "tumble"
-      permalink: "/tumbling/:name/"
 
 # (Remove multilingual keys since plugin is disabled)
 # languages:

--- a/_includes/tumbles-table.html
+++ b/_includes/tumbles-table.html
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-  {% assign items = site.tumbles | sort: "date_started" | reverse %}
+  {% assign items = site.tumble_logs | sort: "date_started" | reverse %}
   {% for t in items %}
     {% assign days = "" %}
     {% if t.date_started and t.date_finished %}

--- a/_notes/tumbling/index.md
+++ b/_notes/tumbling/index.md
@@ -6,7 +6,7 @@ layout: default
 
 # Tumbling Batches
 
-{% assign coll = site.tumble_logs | default: site.tumbles %}
+{% assign coll = site.tumble_logs %}
 {% if coll %}
   {% assign items = coll | sort: "date_started" | reverse %}
 {% else %}


### PR DESCRIPTION
## Summary
- add `tumble_logs` collection with permalink support
- render `tumble_logs` through tumble layout
- update tumbling index and includes to iterate over `site.tumble_logs`

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a48365883268fcb0ec87882de9c