### PR TITLE
style: adopt Cambria and darken chip text

### DIFF
--- a/_notes/tumbling/index.md
+++ b/_notes/tumbling/index.md
@@ -144,7 +144,7 @@ layout: default
 .chips .chip:nth-child(4n+3){background:var(--chip-c)}
 .chips .chip:nth-child(4n+4){background:var(--chip-d)}
 /* rock colours (same as layout, extend as needed) */
-[class^="chip--"]{color:#2b2b26}
+[class^="chip--"]{color:var(--chip-text)}
 /* override any rock-specific backgrounds */
 
 /* status pills */

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -35,7 +35,7 @@ $color-box-background: mix($tiffany-blue, white, 92%); /* soft panel bg */
   --table-row-hover: var(--card-b);
 
   /* Chips */
-  --chip-text: #{mix($rich-black, white, 15%)};
+  --chip-text: #{$color-text};
   --chip-border: var(--panel-border);
   --chip-a: #d4a373;
   --chip-b: #faedcd;
@@ -43,8 +43,8 @@ $color-box-background: mix($tiffany-blue, white, 92%); /* soft panel bg */
   --chip-d: #ccd5ae;
 }
 $border-radius: 4px;
-$font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-  sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+$font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif,
+  Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 
 /* =========================
    Typography & layout


### PR DESCRIPTION
## Summary
- use Cambria as the primary site font
- darken chip text and unify chip color reference

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `ruby scripts/check_assets.rb` *(fails: Missing assets: _tumble_logs/2025-08-21-batch-001.md: /assets/tumbling/001/after-burnish.jpg)*

------
https://chatgpt.com/codex/tasks/task_e_68b13feb06f88326b528dfa29fcf6f3e