### PR TITLE
Add tumble log template and flesh out first batch

### DIFF
--- a/_tumble_logs/2025-08-21-batch-001.md
+++ b/_tumble_logs/2025-08-21-batch-001.md
@@ -21,7 +21,7 @@ rocks:
 
 # Freeform notes
 notes: >
-  This is my first batch ever.
+  This is my first batch ever. I skipped filler media, so a few dalmatian jasper pieces cracked. The coarse stage ran twice (about five days each) to get everything reasonably smooth.
 
 # Brand shown next to grit/polish in stage tables
 consumables_brand: "National Geographic"
@@ -32,7 +32,6 @@ images:
   after_stage_1: "/assets/tumbling/001/after-s1.jpg"
   after_stage_3: "/assets/tumbling/001/after-s3.jpg"
   after_stage_4: "/assets/tumbling/001/after-s4.jpg"
-  after_burnish: "/assets/tumbling/001/after-burnish.jpg"
   gallery: []
 
 # Stages (progress is auto-calculated from these where possible)
@@ -40,17 +39,17 @@ stages:
   - stage: 1
     name: "Coarse Grind"
     start: 2025-08-21
-    end:
+    end: 2025-08-31
     grit: "60/90 SiC"
     barrel_fill_pct: "75%"
     water_level: "Just below top layer"
     media_used: "None"
     amount_tbsp: 2
     maintenance: "N/A"
-    observations: "Chipping reduced; froth normal"
+    observations: "Ran twice (~5 days each). No filler media led to chips and cracks; should have removed smooth pieces after first run."
     decision:
-      repeat:
-      why:
+      repeat: yes
+      why: "Needed more smoothing after first run"
     images: []
 
   - stage: 2
@@ -60,13 +59,13 @@ stages:
     grit: "120/220 SiC"
     barrel_fill_pct: "Use media ~30% of load"
     water_level: "Just below top layer"
-    media_used: "Plastic pellets? Ceramic? Approx. 30% of load"
+    media_used: "None"
     amount_tbsp: 2
     maintenance: "Top-ups; noise/leaks; mid-week checks"
-    observations: "Scratch removal progress; size balance; any chips?"
+    observations: "Still learning what to look for; some stones probably needed another round, but everything moved forward."
     decision:
-      repeat:
-      why:
+      repeat: no
+      why: "Advanced despite imperfections"
     images:
       - "/assets/tumbling/001/after-s1.jpg"
 
@@ -77,14 +76,15 @@ stages:
     grit: "500 SiC"
     barrel_fill_pct: "Maintain 2/3–3/4 full with media"
     water_level: "Just below top layer"
-    media_used: "Add pellets/ceramic to maintain spacing"
+    media_used: "None"
     amount_tbsp: 2
     maintenance: "Rinse checks; lid seal; slurry thickness"
-    observations: "No visible scratches; uniform matte; ready for polish?"
+    observations: "Similar to medium stage; some pits remained but advanced anyway."
     decision:
-      repeat:
-      why:
-    images: []
+      repeat: no
+      why: "Moved ahead despite remaining pits"
+    images:
+      - "/assets/tumbling/001/after-s3.jpg"
 
   - stage: 4
     name: "Polish"
@@ -96,23 +96,24 @@ stages:
     media_used: "Dedicated polish-only media"
     amount_tbsp: 2
     maintenance: "Clean barrel; isolate polish-only media"
-    observations: "Gloss level; haze/orange peel; under-polished spots"
+    observations: "Quartz pieces polished well; others dull or left with grit in pits."
     decision:
       repeat:
       why:
-    images: []
+    images:
+      - "/assets/tumbling/001/after-s4.jpg"
 
   - stage: 5
     name: "Burnish"
     start:
     end:
-    grit: "Soap/Borax burnish"
+    grit: "Soap cycle then gem foam"
     barrel_fill_pct: "Same load; maintain spacing with pellets"
-    water_level: "Full (soap/borax water)"
-    media_used: "Plastic pellets recommended"
+    water_level: "Full"
+    media_used: "Gem foam"
     amount_tbsp:
     maintenance: "Foam control; rinse cycles; contamination check"
-    observations: "Final shine; any haze or foam; orange peel?"
+    observations: "Short soap run then day with gem foam; final shine varied, some haze."
     decision:
       repeat:
       why:
@@ -123,7 +124,7 @@ stages:
 
 # Rock Tumbling Log — Batch 001
 
-_Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
+_Status:_ <span class="badge completed">Completed</span>
 
 ---
 
@@ -135,16 +136,16 @@ _Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
   </thead>
   <tbody>
     <tr><td>Grit</td><td>60/90 SiC (National Geographic)</td></tr>
-    <tr><td>Start Date</td><td>—</td></tr>
-    <tr><td>End Date</td><td>—</td></tr>
-    <tr><td>Duration (days)</td><td>—</td></tr>
-    <tr><td>Barrel Fill %</td><td>—</td></tr>
-    <tr><td>Water Level</td><td>—</td></tr>
-    <tr><td>Media Used</td><td>—</td></tr>
-    <tr><td>Amount (Tbsp)</td><td>—</td></tr>
-    <tr><td>Maintenance</td><td>—</td></tr>
-    <tr><td>Observations</td><td>Chipping, froth, noise, smell</td></tr>
-    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+    <tr><td>Start Date</td><td>2025-08-21</td></tr>
+    <tr><td>End Date</td><td>2025-08-31</td></tr>
+    <tr><td>Duration (days)</td><td>10</td></tr>
+    <tr><td>Barrel Fill %</td><td>75%</td></tr>
+    <tr><td>Water Level</td><td>Just below top layer</td></tr>
+    <tr><td>Media Used</td><td>None</td></tr>
+    <tr><td>Amount (Tbsp)</td><td>2</td></tr>
+    <tr><td>Maintenance</td><td>N/A</td></tr>
+    <tr><td>Observations</td><td>Ran twice (~5 days each). No filler media caused chips and cracks.</td></tr>
+    <tr><td>Decision</td><td>Repeat? Yes — Needed more smoothing</td></tr>
   </tbody>
 </table>
 </div>
@@ -167,8 +168,8 @@ _Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
     <tr><td>Media Used</td><td>—</td></tr>
     <tr><td>Amount (Tbsp)</td><td>—</td></tr>
     <tr><td>Maintenance</td><td>—</td></tr>
-    <tr><td>Observations</td><td>—</td></tr>
-    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+    <tr><td>Observations</td><td>Still figuring it out; some stones likely needed another round but moved forward.</td></tr>
+    <tr><td>Decision</td><td>Repeat? No — Advanced despite imperfections</td></tr>
   </tbody>
 </table>
 </div>
@@ -190,8 +191,8 @@ _Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
     <tr><td>Water Level</td><td>—</td></tr>
     <tr><td>Media Used</td><td>—</td></tr>
     <tr><td>Amount (Tbsp)</td><td>—</td></tr>
-    <tr><td>Observations</td><td>Scratches gone? Even surface?</td></tr>
-    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+    <tr><td>Observations</td><td>Some pits remained but pushed ahead.</td></tr>
+    <tr><td>Decision</td><td>Repeat? No — Moved ahead despite pits</td></tr>
   </tbody>
 </table>
 </div>
@@ -213,7 +214,7 @@ _Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
     <tr><td>Water Level</td><td>—</td></tr>
     <tr><td>Media Used</td><td>Dedicated polish-only media</td></tr>
     <tr><td>Amount (Tbsp)</td><td>—</td></tr>
-    <tr><td>Observations</td><td>Shine level, haze, orange peel</td></tr>
+    <tr><td>Observations</td><td>Quartz polished best; others dull or retained grit in pits.</td></tr>
   </tbody>
 </table>
 </div>
@@ -232,7 +233,7 @@ _Status:_ <span class="badge in-progress">In&nbsp;Progress</span>
     <tr><td>Barrel Fill %</td><td>Same load</td></tr>
     <tr><td>Water Level</td><td>Full</td></tr>
     <tr><td>Media Used</td><td>Plastic pellets recommended</td></tr>
-    <tr><td>Observations</td><td>Final shine? Foam? Any haze?</td></tr>
+    <tr><td>Observations</td><td>Short soap cycle then gem foam; final shine mixed, some haze.</td></tr>
   </tbody>
 </table>
 </div>

--- a/_tumble_logs/batch-template.md
+++ b/_tumble_logs/batch-template.md
@@ -1,0 +1,241 @@
+---
+layout: tumble
+title: "Batch XXX — TITLE"
+batch: "XXX"
+
+# Status options: Pending | In Progress | Completed
+status: Pending
+
+# Dates (YYYY-MM-DD)
+date_started:
+date_finished:
+
+# Gear & context
+tumbler:
+origin:
+rocks:
+  -
+
+# Freeform notes
+notes: >
+  Write notes here.
+
+# Brand shown next to grit/polish in stage tables
+consumables_brand:
+
+# Milestone photos (any can be omitted)
+images:
+  rough: ""
+  after_stage_1: ""
+  after_stage_3: ""
+  after_stage_4: ""
+  gallery: []
+
+# Stages (progress is auto-calculated from these where possible)
+stages:
+  - stage: 1
+    name: "Coarse Grind"
+    start:
+    end:
+    grit:
+    barrel_fill_pct:
+    water_level:
+    media_used:
+    amount_tbsp:
+    maintenance:
+    observations:
+    decision:
+      repeat:
+      why:
+    images: []
+
+  - stage: 2
+    name: "Medium Grind"
+    start:
+    end:
+    grit:
+    barrel_fill_pct:
+    water_level:
+    media_used:
+    amount_tbsp:
+    maintenance:
+    observations:
+    decision:
+      repeat:
+      why:
+    images: []
+
+  - stage: 3
+    name: "Pre-Polish"
+    start:
+    end:
+    grit:
+    barrel_fill_pct:
+    water_level:
+    media_used:
+    amount_tbsp:
+    maintenance:
+    observations:
+    decision:
+      repeat:
+      why:
+    images: []
+
+  - stage: 4
+    name: "Polish"
+    start:
+    end:
+    polish:
+    barrel_fill_pct:
+    water_level:
+    media_used:
+    amount_tbsp:
+    maintenance:
+    observations:
+    decision:
+      repeat:
+      why:
+    images: []
+
+  - stage: 5
+    name: "Burnish"
+    start:
+    end:
+    grit:
+    barrel_fill_pct:
+    water_level:
+    media_used:
+    amount_tbsp:
+    maintenance:
+    observations:
+    decision:
+      repeat:
+      why:
+    images: []
+---
+
+# Rock Tumbling Log — Batch XXX
+
+_Status:_ <span class="badge pending">Pending</span>
+
+---
+
+### Stage 1 — Coarse Grind
+<div class="tumble">
+<table class="tumble-table">
+  <thead>
+    <tr><th>Field</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Grit</td><td>—</td></tr>
+    <tr><td>Start Date</td><td>—</td></tr>
+    <tr><td>End Date</td><td>—</td></tr>
+    <tr><td>Duration (days)</td><td>—</td></tr>
+    <tr><td>Barrel Fill %</td><td>—</td></tr>
+    <tr><td>Water Level</td><td>—</td></tr>
+    <tr><td>Media Used</td><td>—</td></tr>
+    <tr><td>Amount (Tbsp)</td><td>—</td></tr>
+    <tr><td>Maintenance</td><td>—</td></tr>
+    <tr><td>Observations</td><td>—</td></tr>
+    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+  </tbody>
+</table>
+</div>
+
+---
+
+### Stage 2 — Medium Grind
+<div class="tumble">
+<table class="tumble-table">
+  <thead>
+    <tr><th>Field</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Grit</td><td>—</td></tr>
+    <tr><td>Start Date</td><td>—</td></tr>
+    <tr><td>End Date</td><td>—</td></tr>
+    <tr><td>Duration (days)</td><td>—</td></tr>
+    <tr><td>Barrel Fill %</td><td>—</td></tr>
+    <tr><td>Water Level</td><td>—</td></tr>
+    <tr><td>Media Used</td><td>—</td></tr>
+    <tr><td>Amount (Tbsp)</td><td>—</td></tr>
+    <tr><td>Maintenance</td><td>—</td></tr>
+    <tr><td>Observations</td><td>—</td></tr>
+    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+  </tbody>
+</table>
+</div>
+
+---
+
+### Stage 3 — Pre-Polish
+<div class="tumble">
+<table class="tumble-table">
+  <thead>
+    <tr><th>Field</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Grit</td><td>—</td></tr>
+    <tr><td>Start Date</td><td>—</td></tr>
+    <tr><td>End Date</td><td>—</td></tr>
+    <tr><td>Duration (days)</td><td>—</td></tr>
+    <tr><td>Barrel Fill %</td><td>—</td></tr>
+    <tr><td>Water Level</td><td>—</td></tr>
+    <tr><td>Media Used</td><td>—</td></tr>
+    <tr><td>Amount (Tbsp)</td><td>—</td></tr>
+    <tr><td>Observations</td><td>—</td></tr>
+    <tr><td>Decision</td><td>Repeat? Y/N — Why</td></tr>
+  </tbody>
+</table>
+</div>
+
+---
+
+### Stage 4 — Polish
+<div class="tumble">
+<table class="tumble-table">
+  <thead>
+    <tr><th>Field</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Polish</td><td>—</td></tr>
+    <tr><td>Start Date</td><td>—</td></tr>
+    <tr><td>End Date</td><td>—</td></tr>
+    <tr><td>Duration (days)</td><td>—</td></tr>
+    <tr><td>Barrel Fill %</td><td>—</td></tr>
+    <tr><td>Water Level</td><td>—</td></tr>
+    <tr><td>Media Used</td><td>—</td></tr>
+    <tr><td>Amount (Tbsp)</td><td>—</td></tr>
+    <tr><td>Observations</td><td>—</td></tr>
+  </tbody>
+</table>
+</div>
+
+---
+
+### Final Burnish (Post-Polish)
+<div class="tumble">
+<table class="tumble-table">
+  <thead>
+    <tr><th>Field</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Type</td><td>—</td></tr>
+    <tr><td>Duration</td><td>—</td></tr>
+    <tr><td>Barrel Fill %</td><td>—</td></tr>
+    <tr><td>Water Level</td><td>—</td></tr>
+    <tr><td>Media Used</td><td>—</td></tr>
+    <tr><td>Observations</td><td>—</td></tr>
+  </tbody>
+</table>
+</div>
+
+---
+
+### Cleaning Cycles (Between Stages)
+- After each grit stage (1–3), do a **short cleaning run** before moving forward.
+- Use **water + a squirt of dish soap or a spoon of borax**.
+- Run the barrel for a few hours up to 1 full day.
+- Plastic or ceramic media may help scrub surfaces.
+- Purpose: remove leftover grit/slurry and prevent contamination in the next stage.
+


### PR DESCRIPTION
## Summary
- add reusable tumble log template with placeholder metadata and stage tables
- fill out batch 001 log with notes and observations from the accompanying blog post

## Testing
- `ruby scripts/check_assets.rb`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad269f388326af1701fa1797a4fd