### PR TITLE
feat(nav): add breadcrumbs and nested section indexes

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,11 +5,11 @@
 - title: Rockhounding
   url: /rockhounding/
   active_if:
-    path_contains: _notes/rockhounding/
+    url_prefix: /rockhounding/
 - title: Games
   url: /games/
   active_if:
-    path_contains: _notes/games/
+    url_prefix: /games/
 - title: About
   url: /about
   active_if:

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,21 @@
+{% assign segments = include.segments %}
+{% if segments and segments.size > 0 %}
+<nav class="note-breadcrumbs" aria-label="Breadcrumb">
+  <a class="internal-link" href="{{ site.baseurl }}/">Home</a>
+  {% assign crumb_path = '' %}
+  {% for segment in segments %}
+    {% if segment != '' %}
+      {% assign seg_clean = segment | remove: '.md' %}
+      {% assign slug = seg_clean | slugify %}
+      {% assign crumb_path = crumb_path | append: '/' | append: slug %}
+      {% if forloop.last and include.title %}
+        <span class="crumb-divider">/</span>
+        <span aria-current="page">{{ include.title }}</span>
+      {% else %}
+        <span class="crumb-divider">/</span>
+        <a class="internal-link" href="{{ site.baseurl }}{{ crumb_path }}/">{{ seg_clean | replace: '-', ' ' | capitalize }}</a>
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+</nav>
+{% endif %}

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -4,6 +4,9 @@ layout: default
 
 <article>
   <div>
+    {% assign rel_path = page.path | remove_first: '_notes/' %}
+    {% assign segments = rel_path | split: '/' %}
+    {% include breadcrumbs.html segments=segments title=page.title %}
     <h1>{{ page.title }}</h1>
     <time datetime="{{ page.last_modified_at | date_to_xmlschema }}">{% if page.type != 'pages' %}
       Last updated on {{ page.last_modified_at | date: "%B %-d, %Y" }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,5 +3,7 @@ layout: default
 ---
 
 <content>
+  {% assign segments = page.url | split: '/' %}
+  {% include breadcrumbs.html segments=segments title=page.title %}
   {{ content }}
 </content>

--- a/_pages/games/dark-war-survival/guides/index.md
+++ b/_pages/games/dark-war-survival/guides/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Dark War Survival Guides
+permalink: /games/dark-war-survival/guides/
+---
+
+<h1>Dark War Survival Guides</h1>
+
+<ul>
+  {%- assign guide_notes = site.notes | where_exp: "n", "n.path contains '_notes/Games/Dark War Survival/Guides/'" -%}
+  {%- assign guide_sorted = guide_notes | sort: "title" -%}
+  {%- for note in guide_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/games/dark-war-survival/index.md
+++ b/_pages/games/dark-war-survival/index.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Dark War Survival
+permalink: /games/dark-war-survival/
+---
+
+<h1>Dark War Survival</h1>
+
+<h2>Subsections</h2>
+<ul>
+  <li><a class="internal-link" href="{{ site.baseurl }}/games/dark-war-survival/guides/">Guides</a></li>
+</ul>
+
+<h2>Notes</h2>
+<ul>
+  {%- assign dws_notes = site.notes | where_exp: "n", "n.path contains '_notes/Games/Dark War Survival/' and n.path not contains '/Guides/'" -%}
+  {%- assign dws_sorted = dws_notes | sort: "title" -%}
+  {%- for note in dws_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/games/idle-champions/events/index.md
+++ b/_pages/games/idle-champions/events/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: IDLE Champions Events
+permalink: /games/idle-champions/events/
+---
+
+<h1>IDLE Champions Events</h1>
+
+<ul>
+  {%- assign event_notes = site.notes | where_exp: "n", "n.path contains '_notes/Games/IDLE Champions/Events/'" -%}
+  {%- assign event_sorted = event_notes | sort: "title" -%}
+  {%- for note in event_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/games/idle-champions/index.md
+++ b/_pages/games/idle-champions/index.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: IDLE Champions
+permalink: /games/idle-champions/
+---
+
+<h1>IDLE Champions</h1>
+
+<h2>Subsections</h2>
+<ul>
+  <li><a class="internal-link" href="{{ site.baseurl }}/games/idle-champions/events/">Events</a></li>
+</ul>
+
+<h2>Notes</h2>
+<ul>
+  {%- assign ic_notes = site.notes | where_exp: "n", "n.path contains '_notes/Games/IDLE Champions/' and n.path not contains '/Events/'" -%}
+  {%- assign ic_sorted = ic_notes | sort: "title" -%}
+  {%- for note in ic_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/games/index.md
+++ b/_pages/games/index.md
@@ -7,12 +7,6 @@ permalink: /games/
 <h1>Games</h1>
 
 <ul>
-  {%- assign games_notes = site.notes | where_exp: "n", "n.path contains '_notes/games/'" -%}
-  {%- assign games_sorted = games_notes | sort: "title" -%}
-  {%- for note in games_sorted -%}
-  <li>
-    <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-  </li>
-  {%- endfor -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}/games/idle-champions/">IDLE Champions</a></li>
+  <li><a class="internal-link" href="{{ site.baseurl }}/games/dark-war-survival/">Dark War Survival</a></li>
 </ul>
-

--- a/_pages/rockhounding/guides/index.md
+++ b/_pages/rockhounding/guides/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Rockhounding Guides
+permalink: /rockhounding/guides/
+---
+
+<h1>Rockhounding Guides</h1>
+
+<ul>
+  {%- assign guide_notes = site.notes | where_exp: "n", "n.path contains '_notes/Rockhounding/Guides/'" -%}
+  {%- assign guide_sorted = guide_notes | sort: "title" -%}
+  {%- for note in guide_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/rockhounding/index.md
+++ b/_pages/rockhounding/index.md
@@ -7,12 +7,7 @@ permalink: /rockhounding/
 <h1>Rockhounding</h1>
 
 <ul>
-  {%- assign rh_notes = site.notes | where_exp: "n", "n.path contains '_notes/rockhounding/'" -%}
-  {%- assign rh_sorted = rh_notes | sort: "title" -%}
-  {%- for note in rh_sorted -%}
-  <li>
-    <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-  </li>
-  {%- endfor -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}/rockhounding/rocks/">Rocks</a></li>
+  <li><a class="internal-link" href="{{ site.baseurl }}/rockhounding/guides/">Guides</a></li>
+  <li><a class="internal-link" href="{{ site.baseurl }}/tumbling/">Tumbling</a></li>
 </ul>
-

--- a/_pages/rockhounding/rocks/categories/index.md
+++ b/_pages/rockhounding/rocks/categories/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Rock Categories
+permalink: /rockhounding/rocks/categories/
+---
+
+<h1>Rock Categories</h1>
+
+<ul>
+  {%- assign cat_notes = site.notes | where_exp: "n", "n.path contains '_notes/Rockhounding/Rocks/Categories/'" -%}
+  {%- assign cat_sorted = cat_notes | sort: "title" -%}
+  {%- for note in cat_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/rockhounding/rocks/index.md
+++ b/_pages/rockhounding/rocks/index.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Rocks
+permalink: /rockhounding/rocks/
+---
+
+<h1>Rocks</h1>
+
+<h2>Subsections</h2>
+<ul>
+  <li><a class="internal-link" href="{{ site.baseurl }}/rockhounding/rocks/categories/">Categories</a></li>
+  <li><a class="internal-link" href="{{ site.baseurl }}/rockhounding/rocks/minerals/">Minerals</a></li>
+</ul>
+
+<h2>Rock Notes</h2>
+<ul>
+  {%- assign rock_notes = site.notes | where_exp: "n", "n.path contains '_notes/Rockhounding/Rocks/' and n.path not contains '/Minerals/' and n.path not contains '/Categories/'" -%}
+  {%- assign rock_sorted = rock_notes | sort: "title" -%}
+  {%- for note in rock_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_pages/rockhounding/rocks/minerals/index.md
+++ b/_pages/rockhounding/rocks/minerals/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Minerals
+permalink: /rockhounding/rocks/minerals/
+---
+
+<h1>Minerals</h1>
+
+<ul>
+  {%- assign mineral_notes = site.notes | where_exp: "n", "n.path contains '_notes/Rockhounding/Rocks/Minerals/'" -%}
+  {%- assign mineral_sorted = mineral_notes | sort: "title" -%}
+  {%- for note in mineral_sorted -%}
+  <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+  {%- endfor -%}
+</ul>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -245,6 +245,15 @@ nav { margin: 1em 0 3em; }
   border-bottom: 2px solid #{mix($rich-black, white, 70%)};
 }
 
+/* Breadcrumb navigation */
+.note-breadcrumbs {
+  font-size: 0.9em;
+  margin-bottom: 1rem;
+}
+.note-breadcrumbs .crumb-divider {
+  margin: 0 0.3em;
+}
+
 /* Tighter divider spacing on very small screens */
 @media (max-width: 480px) {
   .site-nav .nav-links li + li::before {


### PR DESCRIPTION
## Summary

- What does this PR change and why?

## Changes

- Key updates (files, features, fixes)

## Screenshots / Demos (optional)

- Add before/after or a short clip if helpful

## Checklist

- [ ] Ran `bundle install` (if Gemfile changed)
- [ ] Previewed locally with `bundle exec jekyll serve`
- [ ] Checked `/tumbling/` shows the expected thumbnail(s)
- [ ] Image paths use leading slash (e.g., `/assets/tumbling/<id>/after-s4.jpg`)
- [ ] No zero‑byte images (opened locally to verify)
- [ ] Front matter has required fields (`batch`, `status`, `date_started`, `stages`)
- [ ] Added `images.rough` (Before Tumbling) where available
- [ ] Added most recent stage image(s); `images.after_burnish` if finished
- [ ] Updated docs when behavior changed (`.bundle/CONTRIBUTING.md`)

## Notes for reviewers (optional)

- Special considerations, migration notes, or follow‑ups

