### PR TITLE
fix: correct regex quoting in asset sanity workflow

### DIFF
--- a/.github/workflows/asset-sanity.yml
+++ b/.github/workflows/asset-sanity.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .tmp
-          rg -No "/assets/tumbling/[^"]+" _tumble_logs || true > .tmp/refs.txt
+          rg -No '/assets/tumbling/[^"]+' _tumble_logs || true > .tmp/refs.txt
           if [ ! -s .tmp/refs.txt ]; then
             echo "No referenced tumbling assets found in logs."
             exit 0


### PR DESCRIPTION
## Summary
- fix incorrect regex quoting in asset sanity workflow

## Testing
- `bundle exec rake` *(fails: Could not find jekyll-4.4.1, jekyll-last-modified-at-1.3.2, nokogiri-1.18.9, em-websocket-0.5.3, eventmachine-1.2.7 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68b48060fb148326a087e599be72c4a6