### PR TITLE
chore: run shellcheck on asset sanity scripts

### DIFF
--- a/.github/workflows/asset-sanity.yml
+++ b/.github/workflows/asset-sanity.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@v2
+        with:
+          ignore: tests/**  # adjust as needed
+
       - name: Grep referenced asset paths
         id: grep_paths
         run: |


### PR DESCRIPTION
## Summary
- add ShellCheck step to asset sanity workflow to lint scripts

## Testing
- `bundle exec rake`


------
https://chatgpt.com/codex/tasks/task_e_68b4806151cc8326a67a35d05a7978e0