### PR TITLE
Support nested navigation for Rockhounding pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,6 +6,15 @@
   url: /rockhounding/
   active_if:
     path_contains: _notes/rockhounding/
+  children:
+    - title: Rocks
+      url: /rockhounding/rocks/
+      children:
+        - title: Category
+          url: /rockhounding/rocks/category/
+          children:
+            - title: Igneous Rocks
+              url: /rockhounding/rocks/category/igneous-rocks/
 - title: Games
   url: /games/
   active_if:

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,11 +1,8 @@
-<nav class="site-nav">
-  {% assign is_home = page.url == '/' %}
-  <a class="internal-link nav-home{% if is_home %} nav-link--active{% endif %}"
-     href="{{ site.baseurl }}/"
-     {% if is_home %}aria-current="page"{% endif %}><strong>{{ site.title }}</strong></a>
-  {% if site.data.navigation %}
-  <ul class="nav-links">
-    {% for item in site.data.navigation %}
+{% if include.items %}
+<ul class="nav-links{% if include.level and include.level > 0 %} nav-links--sub{% endif %}">
+  {% assign items = include.items %}
+  {% assign level = include.level | default: 0 %}
+  {% for item in items %}
     {% assign is_active = false %}
     {% if item.active_if %}
       {% if item.active_if.url_exact and page.url == item.active_if.url_exact %}
@@ -26,8 +23,21 @@
       <a class="internal-link{% if is_active %} nav-link--active{% endif %}"
          href="{{ site.baseurl }}{{ item.url }}"
          {% if is_active %}aria-current="page"{% endif %}>{{ item.title }}</a>
+      {% if item.children %}
+        {% assign next_level = level | plus: 1 %}
+        {% include nav.html items=item.children level=next_level %}
+      {% endif %}
     </li>
-    {% endfor %}
-  </ul>
+  {% endfor %}
+</ul>
+{% else %}
+<nav class="site-nav">
+  {% assign is_home = page.url == '/' %}
+  <a class="internal-link nav-home{% if is_home %} nav-link--active{% endif %}"
+     href="{{ site.baseurl }}/"
+     {% if is_home %}aria-current="page"{% endif %}><strong>{{ site.title }}</strong></a>
+  {% if site.data.navigation %}
+    {% include nav.html items=site.data.navigation level=0 %}
   {% endif %}
 </nav>
+{% endif %}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -245,6 +245,23 @@ nav { margin: 1em 0 3em; }
   border-bottom: 2px solid #{mix($rich-black, white, 70%)};
 }
 
+/* Nested navigation lists */
+.site-nav .nav-links--sub {
+  display: block;
+  padding-left: 1rem;
+  margin: 0.3em 0;
+}
+
+.site-nav .nav-links--sub li {
+  display: block;
+}
+
+.site-nav .nav-links--sub li + li::before,
+.site-nav .nav-links--sub::before {
+  content: none;
+  margin: 0;
+}
+
 /* Tighter divider spacing on very small screens */
 @media (max-width: 480px) {
   .site-nav .nav-links li + li::before {


### PR DESCRIPTION
## Summary
- allow nested `Rockhounding` items in navigation data
- render navigation lists recursively, highlighting active links
- style nested navigation levels for clear hierarchy

## Testing
- ⚠️ `bundle exec rake` *(failed: Could not find nokogiri-1.18.9)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fdc73e7c83269e7217b96ab442e8