### PR TITLE
Add reusable rock cards and grid layout

### DIFF
--- a/_includes/rock-card.html
+++ b/_includes/rock-card.html
@@ -1,0 +1,14 @@
+<div class="rock-card">
+  {% assign thumb = include.rock.thumbnail | default: include.rock.cover %}
+  {% if thumb %}
+    <a href="{{ include.rock.url | relative_url }}">
+      <img src="{{ thumb | relative_url }}" alt="{{ include.rock.title }}">
+    </a>
+  {% endif %}
+  <h3><a href="{{ include.rock.url | relative_url }}">{{ include.rock.title }}</a></h3>
+  {% if include.rock.description %}
+    <p>{{ include.rock.description }}</p>
+  {% else %}
+    <p>{{ include.rock.excerpt | strip_html | truncate: 160 }}</p>
+  {% endif %}
+</div>

--- a/_notes/rockhounding/guides/Rocks and Minerals.md
+++ b/_notes/rockhounding/guides/Rocks and Minerals.md
@@ -2,38 +2,11 @@
 title: Rocks and Minerals
 layout: note
 ---
-## A
-- [[agate]]
-
-## B
-- [[breccia]]
-
-## C
-- [[calcite]]
-- [[conglomerate]]
-
-## E
-- [[epidote]]
-
-## F
-- [[feldspar]]
-- [[fluorite]]
-
-## G
-- [[garnet]]
-- [[gneiss]]
-
-## J
-- [[jasper]]
-
-## L
-- [[limestone]]
-
-## P
-- [[pyrite]]
-
-## Q
-- [[quartz]]
-
-## U
-- [[unakite]]
+<div class="rock-card-grid">
+{% assign rocks = site.notes | where_exp: "p", "p.path contains '_notes/rockhounding/rocks/'" | sort: 'title' %}
+{% for rock in rocks %}
+  {% unless rock.path contains '/category/' or rock.path contains '/categories/' %}
+    {% include rock-card.html rock=rock %}
+  {% endunless %}
+{% endfor %}
+</div>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -609,3 +609,51 @@ code {
 .t-thumb.is-placeholder {
   filter: grayscale(0.25) opacity(0.9);
 }
+
+/* Rock card grid */
+.rock-card-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.rock-card {
+  background: var(--card-a);
+  border: 1px solid var(--panel-border);
+  border-radius: $border-radius;
+  padding: 0.75rem;
+  transition: background 0.2s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.rock-card:hover {
+  background: var(--card-b);
+}
+
+.rock-card img {
+  width: 100%;
+  height: auto;
+  border-radius: $border-radius;
+  margin-bottom: 0.5rem;
+}
+
+.rock-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1em;
+}
+
+.rock-card h3 a {
+  text-decoration: none;
+  border-bottom: none;
+  color: inherit;
+}
+
+.rock-card h3 a:hover {
+  text-decoration: underline;
+}
+
+.rock-card p {
+  margin: 0;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- create `rock-card` include with optional thumbnail, linked title, and description
- style `.rock-card` and `.rock-card-grid` using existing card variables
- replace manual rock list with a dynamic card grid looping over rock notes

## Testing
- `bundle exec jekyll build`
- `ruby scripts/check_assets.rb`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68b5151255588326b4c54096a2800b95