### PR TITLE
Add breadcrumb navigation, simplify main nav, restructure content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ sass:
 collections:
   notes:
     output: true
-    permalink: /:slug
+    permalink: /:path/
 
 # --- Defaults (layouts, etc.) ---
 defaults:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,28 +1,23 @@
-- title: Tumbling
-  url: /tumbling/
+- title: Blog
+  url: /blog/
   active_if:
-    url_prefix: /tumbling/
-- title: Rockhounding
-  url: /rockhounding/
-  active_if:
-    path_contains: _notes/rockhounding/
-- title: Rock Categories
-  url: /rockhounding/rocks/category/
-  active_if:
-    path_contains: _notes/rockhounding/rocks/category/
-  children:
-    - title: Rocks
-      url: /rockhounding/rocks/
-      children:
-        - title: Category
-          url: /rockhounding/rocks/category/
-          children:
-            - title: Igneous Rocks
-              url: /rockhounding/rocks/category/igneous/
+    url_prefix: /blog/
 - title: Games
   url: /games/
   active_if:
     path_contains: _notes/games/
+  children:
+    - title: IDLE Champions
+      url: /games/idle-champions/
+    - title: Dark War Survival
+      url: /games/dark-war-survival/
+- title: Hobbies
+  url: /hobbies/
+  active_if:
+    path_contains: rockhounding
+  children:
+    - title: Rockhounding
+      url: /rockhounding/
 - title: About
   url: /about
   active_if:

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,57 @@
+{%- comment -%}
+  Breadcrumbs include
+  Usage: included automatically from default layout. Builds crumbs from page.url
+  and attempts to resolve titles by matching site.pages and site.notes by URL.
+  Fallback: humanize URL segments if no page found.
+{%- endcomment -%}
+
+{%- assign url = page.url | default: '/' -%}
+{%- assign parts = url | split: '/' -%}
+{%- assign parts = parts | reject: '' -%}
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a class="internal-link" href="{{ site.baseurl }}/">{{ site.title }}</a>
+
+  {%- if page.breadcrumbs and page.breadcrumbs.size > 0 -%}
+    {%- for bc in page.breadcrumbs -%}
+      <span class="crumb-sep">›</span>
+      <a class="internal-link" href="{{ bc.url | relative_url }}">{{ bc.title }}</a>
+    {%- endfor -%}
+    <span class="crumb-sep">›</span>
+    <span aria-current="page">{{ page.title }}</span>
+  {%- else -%}
+    {%- assign accum = '' -%}
+    {%- for seg in parts -%}
+      {%- assign accum = accum | append: '/' | append: seg -%}
+      {%- assign target = accum | append: '/' -%}
+      {%- assign is_last = forloop.last -%}
+
+      {%- assign match = nil -%}
+      {%- assign pages = site.pages | where: 'url', target -%}
+      {%- if pages and pages.size > 0 -%}
+        {%- assign match = pages[0] -%}
+      {%- endif -%}
+      {%- if match == nil and site.notes -%}
+        {%- assign notes = site.notes | where: 'url', target -%}
+        {%- if notes and notes.size > 0 -%}
+          {%- assign match = notes[0] -%}
+        {%- endif -%}
+      {%- endif -%}
+
+      {%- assign label = nil -%}
+      {%- if match and match.title -%}
+        {%- assign label = match.title -%}
+      {%- else -%}
+        {%- assign label = seg | replace: '-', ' ' | capitalize -%}
+      {%- endif -%}
+
+      <span class="crumb-sep">›</span>
+      {%- if is_last -%}
+        <span aria-current="page">{{ label }}</span>
+      {%- else -%}
+        <a class="internal-link" href="{{ site.baseurl }}{{ target }}">{{ label }}</a>
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+</nav>
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,9 @@
   <body>
     {% include nav.html %}
     <div class="wrapper">
+      {% unless page.url == '/' %}
+        {% include breadcrumbs.html %}
+      {% endunless %}
       <main>{{ content }}</main>
       <footer>{% include footer.html %}</footer>
     </div>

--- a/_notes/rockhounding/guides/Books.md
+++ b/_notes/rockhounding/guides/Books.md
@@ -1,7 +1,0 @@
----
-title: Books
-layout: note
----
-
-[National Geographic Pocket Guide to Rocks and Minerals of North America by National Geographic Society \| Goodreads](https://www.goodreads.com/book/show/18167012-national-geographic-pocket-guide-to-rocks-and-minerals-of-north-america)
-

--- a/_notes/rockhounding/guides/Field Testing Hardness.md
+++ b/_notes/rockhounding/guides/Field Testing Hardness.md
@@ -1,0 +1,7 @@
+---
+title: Field Testing Hardness
+layout: note
+---
+
+Coming soon. See also: [[Mohs Hardness Scale]].
+

--- a/_notes/rockhounding/guides/How to Tumble Rocks.md
+++ b/_notes/rockhounding/guides/How to Tumble Rocks.md
@@ -1,0 +1,7 @@
+---
+title: How to Tumble Rocks
+layout: note
+---
+
+This is a quick entry point to my tumbling notes. For a full guide, see [[Rock Tumbling]].
+

--- a/_notes/rockhounding/resources/Books.md
+++ b/_notes/rockhounding/resources/Books.md
@@ -1,0 +1,7 @@
+---
+title: Books
+layout: note
+---
+
+[National Geographic Pocket Guide to Rocks and Minerals of North America by National Geographic Society | Goodreads](https://www.goodreads.com/book/show/18167012-national-geographic-pocket-guide-to-rocks-and-minerals-of-north-america)
+

--- a/_notes/rockhounding/rocks/igneous/basalt.md
+++ b/_notes/rockhounding/rocks/igneous/basalt.md
@@ -1,0 +1,7 @@
+---
+title: Basalt (Igneous)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/igneous/obsidian.md
+++ b/_notes/rockhounding/rocks/igneous/obsidian.md
@@ -1,0 +1,7 @@
+---
+title: Obsidian (Igneous)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/igneous/rhyolite.md
+++ b/_notes/rockhounding/rocks/igneous/rhyolite.md
@@ -1,0 +1,7 @@
+---
+title: Rhyolite (Igneous)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/metamorphic/marble.md
+++ b/_notes/rockhounding/rocks/metamorphic/marble.md
@@ -1,0 +1,7 @@
+---
+title: Marble (Metamorphic)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/metamorphic/quartzite.md
+++ b/_notes/rockhounding/rocks/metamorphic/quartzite.md
@@ -1,0 +1,7 @@
+---
+title: Quartzite (Metamorphic)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/metamorphic/schist.md
+++ b/_notes/rockhounding/rocks/metamorphic/schist.md
@@ -1,0 +1,7 @@
+---
+title: Schist (Metamorphic)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/metamorphic/slate.md
+++ b/_notes/rockhounding/rocks/metamorphic/slate.md
@@ -1,0 +1,7 @@
+---
+title: Slate (Metamorphic)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/metamorphic/soapstone.md
+++ b/_notes/rockhounding/rocks/metamorphic/soapstone.md
@@ -1,0 +1,7 @@
+---
+title: Soapstone (Metamorphic)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/amethyst.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/amethyst.md
@@ -1,0 +1,7 @@
+---
+title: Amethyst (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/aventurine.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/aventurine.md
@@ -1,0 +1,7 @@
+---
+title: Aventurine (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/coldwater-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/coldwater-agate.md
@@ -1,0 +1,7 @@
+---
+title: Coldwater Agate
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/index.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/index.md
@@ -1,0 +1,7 @@
+---
+title: Agate (Chalcedony)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/lake-superior-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/lake-superior-agate.md
@@ -1,0 +1,7 @@
+---
+title: Lake Superior Agate
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/fire-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/fire-agate.md
@@ -1,0 +1,7 @@
+---
+title: Fire Agate (Chalcedony)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/heliotrope.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/heliotrope.md
@@ -1,0 +1,7 @@
+---
+title: Heliotrope (Bloodstone)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/index.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/index.md
@@ -1,0 +1,7 @@
+---
+title: Chalcedony (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/moss-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/moss-agate.md
@@ -1,0 +1,7 @@
+---
+title: Moss Agate (Chalcedony)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/onyx.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/onyx.md
@@ -1,0 +1,7 @@
+---
+title: Onyx (Chalcedony)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/jasper/banded-jasper.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/jasper/banded-jasper.md
@@ -1,0 +1,7 @@
+---
+title: Banded Jasper (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/jasper/picture-jasper.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/jasper/picture-jasper.md
@@ -1,0 +1,7 @@
+---
+title: Picture Jasper (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/milky-quartz.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/milky-quartz.md
@@ -1,0 +1,7 @@
+---
+title: Milky Quartz
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/rose-quartz.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/rose-quartz.md
@@ -1,0 +1,7 @@
+---
+title: Rose Quartz
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/smoky-quartz.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/smoky-quartz.md
@@ -1,0 +1,7 @@
+---
+title: Smoky Quartz
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/minerals/quartz/tiger-eye.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/tiger-eye.md
@@ -1,0 +1,7 @@
+---
+title: Tiger Eye (Quartz)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/sedimentary/banded-iron-formation.md
+++ b/_notes/rockhounding/rocks/sedimentary/banded-iron-formation.md
@@ -1,0 +1,7 @@
+---
+title: Banded Iron Formation (Sedimentary)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/sedimentary/chert.md
+++ b/_notes/rockhounding/rocks/sedimentary/chert.md
@@ -1,0 +1,7 @@
+---
+title: Chert (Sedimentary)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/sedimentary/sandstone.md
+++ b/_notes/rockhounding/rocks/sedimentary/sandstone.md
@@ -1,0 +1,7 @@
+---
+title: Sandstone (Sedimentary)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/rocks/sedimentary/shale.md
+++ b/_notes/rockhounding/rocks/sedimentary/shale.md
@@ -1,0 +1,7 @@
+---
+title: Shale (Sedimentary)
+layout: note
+---
+
+Coming soon.
+

--- a/_notes/rockhounding/tumbling/index.md
+++ b/_notes/rockhounding/tumbling/index.md
@@ -2,6 +2,9 @@
 title: Tumbling Batches
 permalink: /tumbling/
 layout: default
+breadcrumbs:
+  - title: Rockhounding
+    url: /rockhounding/
 ---
 
 # Tumbling Batches

--- a/_pages/blog/index.md
+++ b/_pages/blog/index.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+<h1>Blog</h1>
+
+<ul>
+  {%- assign posts = site.notes | where_exp: "n", "n.path contains '_notes/blog/'" -%}
+  {%- assign posts = posts | sort: 'last_modified_at' | reverse -%}
+  {%- for note in posts -%}
+    <li>
+      <a class="internal-link" href="{{ note.url | relative_url }}">{{ note.title }}</a>
+      {%- if note.last_modified_at -%}
+        <small> — {{ note.last_modified_at | date: "%b %-d, %Y" }}</small>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/games/dark-war-survival/index.md
+++ b/_pages/games/dark-war-survival/index.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Dark War Survival
+permalink: /games/dark-war-survival/
+---
+
+<h1>Dark War Survival</h1>
+
+<ul>
+  {%- assign notes = site.notes | where_exp: "n", "n.path contains '_notes/games/Dark War Survival/'" -%}
+  {%- assign notes = notes | sort: 'title' -%}
+  {%- for n in notes -%}
+    <li><a class="internal-link" href="{{ n.url | relative_url }}">{{ n.title }}</a></li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/games/idle-champions/index.md
+++ b/_pages/games/idle-champions/index.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: IDLE Champions
+permalink: /games/idle-champions/
+---
+
+<h1>IDLE Champions</h1>
+
+<ul>
+  {%- assign notes = site.notes | where_exp: "n", "n.path contains '_notes/games/IDLE Champions/'" -%}
+  {%- assign notes = notes | sort: 'title' -%}
+  {%- for n in notes -%}
+    <li><a class="internal-link" href="{{ n.url | relative_url }}">{{ n.title }}</a></li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/games/index.md
+++ b/_pages/games/index.md
@@ -7,12 +7,6 @@ permalink: /games/
 <h1>Games</h1>
 
 <ul>
-  {%- assign games_notes = site.notes | where_exp: "n", "n.path contains '_notes/games/'" -%}
-  {%- assign games_sorted = games_notes | sort: "title" -%}
-  {%- for note in games_sorted -%}
-  <li>
-    <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-  </li>
-  {%- endfor -%}
+  <li><a class="internal-link" href="{{ '/games/idle-champions/' | relative_url }}">IDLE Champions</a></li>
+  <li><a class="internal-link" href="{{ '/games/dark-war-survival/' | relative_url }}">Dark War Survival</a></li>
 </ul>
-

--- a/_pages/hobbies/index.md
+++ b/_pages/hobbies/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Hobbies
+permalink: /hobbies/
+---
+
+<h1>Hobbies</h1>
+
+<ul>
+  <li><a class="internal-link" href="{{ '/rockhounding/' | relative_url }}">Rockhounding</a></li>
+</ul>
+

--- a/_pages/rockhounding/guides/index.md
+++ b/_pages/rockhounding/guides/index.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Guides
+permalink: /rockhounding/guides/
+---
+
+<h1>Guides</h1>
+
+<ul>
+  {%- assign notes = site.notes | where_exp: "n", "n.path contains '_notes/rockhounding/guides/'" -%}
+  {%- assign notes = notes | sort: 'title' -%}
+  {%- for n in notes -%}
+    <li><a class="internal-link" href="{{ n.url | relative_url }}">{{ n.title }}</a></li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/rockhounding/index.md
+++ b/_pages/rockhounding/index.md
@@ -7,12 +7,10 @@ permalink: /rockhounding/
 <h1>Rockhounding</h1>
 
 <ul>
-  {%- assign rh_notes = site.notes | where_exp: "n", "n.path contains '_notes/rockhounding/'" -%}
-  {%- assign rh_sorted = rh_notes | sort: "title" -%}
-  {%- for note in rh_sorted -%}
-  <li>
-    <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-  </li>
-  {%- endfor -%}
+  <li><a class="internal-link" href="{{ '/rockhounding/guides/' | relative_url }}">Guides</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/resources/' | relative_url }}">Resources</a></li>
+  <li><a class="internal-link" href="{{ '/tumbling/' | relative_url }}">Tumbling</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/' | relative_url }}">Rocks</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/minerals/' | relative_url }}">Minerals</a></li>
+  
 </ul>
-

--- a/_pages/rockhounding/resources/articles.md
+++ b/_pages/rockhounding/resources/articles.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Articles
+permalink: /rockhounding/resources/articles/
+---
+
+Coming soon.
+

--- a/_pages/rockhounding/resources/index.md
+++ b/_pages/rockhounding/resources/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Resources
+permalink: /rockhounding/resources/
+---
+
+<h1>Resources</h1>
+
+<ul>
+  <li><a class="internal-link" href="{{ '/rockhounding/resources/books/' | relative_url }}">Books</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/resources/websites/' | relative_url }}">Websites</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/resources/articles/' | relative_url }}">Articles</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/resources/social-media/' | relative_url }}">Social Media</a></li>
+</ul>
+

--- a/_pages/rockhounding/resources/social-media.md
+++ b/_pages/rockhounding/resources/social-media.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Social Media
+permalink: /rockhounding/resources/social-media/
+---
+
+Coming soon.
+

--- a/_pages/rockhounding/resources/websites.md
+++ b/_pages/rockhounding/resources/websites.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Websites
+permalink: /rockhounding/resources/websites/
+---
+
+Coming soon.
+

--- a/_pages/rockhounding/rocks/index.md
+++ b/_pages/rockhounding/rocks/index.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Rocks
+permalink: /rockhounding/rocks/
+---
+
+<h1>Rocks</h1>
+
+<h2>By Category</h2>
+<ul>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/category/igneous/' | relative_url }}">Igneous</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/category/metamorphic/' | relative_url }}">Metamorphic</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/category/sedimentary/' | relative_url }}">Sedimentary</a></li>
+  <li><a class="internal-link" href="{{ '/rockhounding/rocks/minerals/' | relative_url }}">Minerals</a></li>
+  
+</ul>
+
+<h2>All Rocks</h2>
+<ul>
+  {%- assign items = site.notes | where_exp: "n", "n.path contains '_notes/rockhounding/rocks/'" -%}
+  {%- assign items = items | reject: 'path', '_notes/rockhounding/rocks/category/index.md' -%}
+  {%- assign items = items | where_exp: "n", "n.path contains '/rocks/' and n.path contains '/minerals/' == false and n.path contains '/category/' == false" -%}
+  {%- assign items = items | sort: 'title' -%}
+  {%- for n in items -%}
+    <li><a class="internal-link" href="{{ n.url | relative_url }}">{{ n.title }}</a></li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/rockhounding/rocks/minerals/index.md
+++ b/_pages/rockhounding/rocks/minerals/index.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Minerals
+permalink: /rockhounding/rocks/minerals/
+---
+
+<h1>Minerals</h1>
+
+<ul>
+  {%- assign items = site.notes | where_exp: "n", "n.path contains '_notes/rockhounding/rocks/minerals/'" -%}
+  {%- assign items = items | sort: 'title' -%}
+  {%- for n in items -%}
+    <li><a class="internal-link" href="{{ n.url | relative_url }}">{{ n.title }}</a></li>
+  {%- endfor -%}
+</ul>
+

--- a/_pages/tumbling/index.md
+++ b/_pages/tumbling/index.md
@@ -2,9 +2,11 @@
 layout: page
 title: Tumbling
 permalink: /tumbling/
+breadcrumbs:
+  - title: Rockhounding
+    url: /rockhounding/
 ---
 
 <h1>Tumbling</h1>
 
 {% include tumbles-table.html %}
-

--- a/_pages/tumbling/log-checklist.md
+++ b/_pages/tumbling/log-checklist.md
@@ -2,6 +2,9 @@
 layout: note
 title: Tumbling Log Checklist
 permalink: /tumbling/log-checklist/
+breadcrumbs:
+  - title: Rockhounding
+    url: /rockhounding/
 ---
 
 # Tumbling Log Checklist
@@ -84,4 +87,3 @@ Provide the following for each stage you run. Stages are typically 1–5.
 - Keep at least one clear “final” photo (Stage 4 or Burnish) — it’s used prominently.
 - If a stage is skipped, omit it or leave fields blank; the layout will fall back to the nearest reasonable image.
 - Set both `batch` and `title` — the index shows “Batch — Title”.
-

--- a/styles.scss
+++ b/styles.scss
@@ -3,3 +3,13 @@
 @import "normalize";
 @import "code";
 @import "style";
+
+/* Breadcrumbs */
+.breadcrumbs {
+  font-size: 0.95rem;
+  color: var(--muted, #666);
+  margin: 0.75rem 0 1rem;
+}
+.breadcrumbs a { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
+.breadcrumbs a:hover { color: inherit; text-decoration: underline; }
+.crumb-sep { margin: 0 0.4rem; color: var(--muted, #888); }


### PR DESCRIPTION
- Add breadcrumbs include and render it before main
- Style breadcrumbs
- Curate header nav to Blog, Games (IDLE Champions, Dark War Survival), Hobbies (Rockhounding), and About; remove deep links
- Switch notes to path-based permalinks (/:path/) for hierarchical URLs
- Add landing pages: /blog/, /hobbies/, /rockhounding/ (links to Guides, Resources, Tumbling, Rocks, Minerals)
- Add Rockhounding sub-pages: Guides index; Resources index + Books/Websites/ Articles/Social Media; Rocks index; Minerals index
- Add Games subsections: /games/idle-champions/, /games/dark-war-survival/
- Add breadcrumbs to Tumbling pages and keep /tumbling/ under Rockhounding in UI
- Move “Books” note from guides → resources
- Add guides stubs: Field Testing Hardness; How to Tumble Rocks
- Add rock/mineral stubs (igneous/metamorphic/sedimentary + quartz variants, including chalcedony/agate subtypes)