### PR TITLE
Fix Liquid include and adjust Netlify build command

### DIFF
--- a/_pages/rockhounding/index.md
+++ b/_pages/rockhounding/index.md
@@ -2,6 +2,22 @@
 layout: page
 title: Rockhounding
 permalink: /rockhounding/
+rocks:
+  - url: '/rockhounding/rocks/'
+    title: 'Rocks'
+    description: 'Igneous, metamorphic, and sedimentary pages with key tells, photos, and Ontario context.'
+  - url: '/rockhounding/rocks/minerals/'
+    title: 'Minerals'
+    description: 'Rock‑forming minerals with quick tests (hardness, streak) and in‑the‑field visuals.'
+  - url: '/rockhounding/guides/'
+    title: 'Guides'
+    description: 'Where to go, what to bring, how to look—plus safety, ethics, and beginner IDs.'
+  - url: '/tumbling/'
+    title: 'Tumbling'
+    description: 'Grit/media recipes, step‑by‑step runs, and troubleshooting notes from real batches.'
+  - url: '/rockhounding/resources/'
+    title: 'Resources'
+    description: 'Curated books, websites, articles, and social accounts; books sync from my Goodreads shelf.'
 ---
 
 <h1>Rockhounding</h1>
@@ -11,35 +27,9 @@ permalink: /rockhounding/
 <p><em>Regional focus: Lake Ontario’s north shore and Southern Ontario; methods apply broadly.</em></p>
 
 <div class="rock-card-grid">
-  {% include rock-card.html rock={
-    url: '/rockhounding/rocks/',
-    title: 'Rocks',
-    description: 'Igneous, metamorphic, and sedimentary pages with key tells, photos, and Ontario context.'
-  } %}
-
-  {% include rock-card.html rock={
-    url: '/rockhounding/rocks/minerals/',
-    title: 'Minerals',
-    description: 'Rock‑forming minerals with quick tests (hardness, streak) and in‑the‑field visuals.'
-  } %}
-
-  {% include rock-card.html rock={
-    url: '/rockhounding/guides/',
-    title: 'Guides',
-    description: 'Where to go, what to bring, how to look—plus safety, ethics, and beginner IDs.'
-  } %}
-
-  {% include rock-card.html rock={
-    url: '/tumbling/',
-    title: 'Tumbling',
-    description: 'Grit/media recipes, step‑by‑step runs, and troubleshooting notes from real batches.'
-  } %}
-
-  {% include rock-card.html rock={
-    url: '/rockhounding/resources/',
-    title: 'Resources',
-    description: 'Curated books, websites, articles, and social accounts; books sync from my Goodreads shelf.'
-  } %}
+  {% for rock in page.rocks %}
+    {% include rock-card.html rock=rock %}
+  {% endfor %}
 </div>
 
 <h2>Quick Links</h2>

--- a/_pages/rockhounding/resources/books.md
+++ b/_pages/rockhounding/resources/books.md
@@ -8,7 +8,7 @@ permalink: /rockhounding/resources/books/
 
 <p>Live list pulled from my Goodreads <em>geology</em> shelf.</p>
 
-{% assign books = site.data.goodreads.geology | default: [] %}
+{% assign books = site.data.goodreads.geology %}
 
 {% if books.size == 0 %}
   <p><em>No books found yet.</em> If you’re seeing this during a fresh build, the Goodreads feed may not have loaded or the shelf is empty.</p>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "bundle install && bundle exec jekyll build --trace"
+  command = "bundle exec jekyll build --trace"
   publish = "_site"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- define rock card metadata in front matter and loop through entries
- remove Goodreads default filter warning
- streamline Netlify build command to rely on Bundler environment

## Testing
- `bundle exec rake test`
- `PYTHONPATH=. pytest tests`
- `bundle exec jekyll build --trace`


------
https://chatgpt.com/codex/tasks/task_e_68b6864a614483268f699c1921e80e2d