### PR TITLE
Fix Liquid include and adjust Netlify build command

### DIFF
--- a/_pages/rockhounding/resources/books.md
+++ b/_pages/rockhounding/resources/books.md
@@ -8,7 +8,7 @@ permalink: /rockhounding/resources/books/
 
 <p>Live list pulled from my Goodreads <em>geology</em> shelf.</p>
 
-{% assign books = site.data.goodreads.geology %}
+{% assign books = site.data.goodreads.geology | default: [] %}
 
 {% if books.size == 0 %}
   <p><em>No books found yet.</em> If you’re seeing this during a fresh build, the Goodreads feed may not have loaded or the shelf is empty.</p>


### PR DESCRIPTION
## Summary
- define rock card metadata in front matter and loop through entries
- remove Goodreads default filter warning
- streamline Netlify build command to rely on Bundler environment
- guard against missing Goodreads dataset

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `PYTHONPATH=. pytest tests`
- `bundle exec jekyll build --trace` *(fails: Could not find nokogiri-1.18.9)*

------
https://chatgpt.com/codex/tasks/task_e_68b688961a8c83269ed29b988ec27e7a