### PR TITLE
docs: refresh tumbling admin checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Generate summaries locally and in CI for easier PR descriptions and reviews.
   - Old URLs like `/rockhounding/rocks/category/{igneous|metamorphic|sedimentary}/` and top‑level rock pages (e.g., `/rockhounding/rocks/granite/`) now redirect to their new locations.
   - Redirect rules are defined in `netlify.toml`. Please update internal links to point to the new paths to avoid redirect hops.
 
+- Administrative checklist
+  - The tumbling log checklist lives at [`_pages/tumbling/log-checklist.md`](_pages/tumbling/log-checklist.md) (served at `/tumbling/log-checklist/`). Use it when adding or updating tumbling batch logs.
+
 ## License
 
 Source code is available under the [MIT license](LICENSE.md).

--- a/_pages/tumbling/log-checklist.md
+++ b/_pages/tumbling/log-checklist.md
@@ -10,16 +10,18 @@ breadcrumbs:
 # Tumbling Log Checklist
 
 Use this checklist when creating or updating a tumbling batch log so everything renders nicely in the index and detail views.
+This page replaces the old `/admin` path.
 
 ## Required Images
 - [ ] Rough load photo (`images.rough`)
 - [ ] Final result photo — pick one of:
   - [ ] After Stage 4 (`images.after_stage_4`)
   - [ ] After Burnish (`images.after_burnish`)
-- [ ] Optional progress photos (helpful, not required):
-  - [ ] After Stage 1 (`images.after_stage_1`)
-  - [ ] After Stage 2 (`images.after_stage_2`)
-  - [ ] After Stage 3 (`images.after_stage_3`)
+  - [ ] Optional progress photos (helpful, not required):
+    - [ ] After Stage 1 (`images.after_stage_1`)
+    - [ ] After Stage 2 (`images.after_stage_2`)
+    - [ ] After Stage 3 (`images.after_stage_3`)
+    - [ ] After Stage 5 (if applicable) (`images.after_stage_5`)
 - Notes
   - The page will automatically choose a cover image in this order: `cover` → `after_stage_4` → `after_burnish` → `rough`.
   - The index uses the best available image in this order: `cover` → `after_stage_5` → `after_stage_4` → `after_stage_3` → `after_stage_2` → `after_stage_1` → `after_burnish` → `rough`.


### PR DESCRIPTION
## Summary
- document tumbling log checklist in README
- note admin page relocation and optional Stage 5 photo

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `ruby scripts/check_assets.rb`
- `python3 scripts/check_site_links.py` *(fails: _site not found. Build the site first: bundle exec jekyll build)*

------
https://chatgpt.com/codex/tasks/task_e_68b6905476188326bd1b279aaebda759