### PR TITLE
Restrict ahead_behind to CalledProcessError

### DIFF
--- a/git_push.py
+++ b/git_push.py
@@ -47,7 +47,7 @@ def ahead_behind(upstream, branch):
         s = out(["git", "rev-list", "--left-right", "--count", f"{upstream}...{branch}"])
         left, right = s.split()
         return int(left), int(right)
-    except Exception:
+    except sp.CalledProcessError:
         return (0, 0)
 
 def ensure_on_branch(branch: str, *, auto_branch: bool = False) -> str:

--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -127,13 +127,23 @@ def test_ahead_behind_parses_counts(monkeypatch):
     assert git_push.ahead_behind("origin/main", "main") == (2, 5)
 
 
-def test_ahead_behind_on_exception_returns_zeros(monkeypatch):
+def test_ahead_behind_on_calledprocesserror_returns_zeros(monkeypatch):
+    monkeypatch.setattr(
+        git_push,
+        "out",
+        lambda *_: (_ for _ in ()).throw(sp.CalledProcessError(returncode=2, cmd=["git"])),
+    )
+    assert git_push.ahead_behind("origin/main", "main") == (0, 0)
+
+
+def test_ahead_behind_other_exception_propagates(monkeypatch):
     monkeypatch.setattr(
         git_push,
         "out",
         lambda *_: (_ for _ in ()).throw(RuntimeError("oops")),
     )
-    assert git_push.ahead_behind("origin/main", "main") == (0, 0)
+    with pytest.raises(RuntimeError):
+        git_push.ahead_behind("origin/main", "main")
 
 
 def test_main_first_push_with_commit(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- Avoid masking unexpected errors in `ahead_behind` by catching only `subprocess.CalledProcessError`
- Add tests ensuring `ahead_behind` returns `(0, 0)` only for `CalledProcessError` and propagates other exceptions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6915d99108326ba4063f02defa455