### PR TITLE
Ensure git_push tests locate module

### DIFF
--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -1,7 +1,10 @@
+import os
 import subprocess as sp
 import sys
 
 import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import git_push
 


### PR DESCRIPTION
## Summary
- Add repository root to `sys.path` so tests can import `git_push`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6917da9848326b8d7b96d91c9e5e8