### PR TITLE
Explicitly rescue StandardError in Goodreads shelf generator

### DIFF
--- a/_plugins/goodreads_shelf.rb
+++ b/_plugins/goodreads_shelf.rb
@@ -23,7 +23,7 @@ class GoodreadsShelfGenerator < Jekyll::Generator
         items = parse_items(xml)
         site.data['goodreads'][name] = items
         Jekyll.logger.info("Goodreads:", "Loaded #{items.length} items for '#{name}' shelf")
-      rescue => e
+      rescue StandardError => e
         Jekyll.logger.warn("Goodreads:", "Failed to load '#{name}' shelf: #{e.class} #{e.message}")
         site.data['goodreads'][name] ||= []
       end


### PR DESCRIPTION
## Summary
- Clarify Goodreads shelf generator error handling by rescuing `StandardError` instead of all exceptions

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*

------
https://chatgpt.com/codex/tasks/task_e_68b69195e1e083268d60fb15bcbaa42c