### PR TITLE
Handle self-closing image tags

### DIFF
--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -40,6 +40,10 @@ class LinkParser(HTMLParser):
         elif tag == "img" and "src" in attr_dict:
             self.srcs.append(attr_dict["src"])
 
+    def handle_startendtag(self, tag, attrs):
+        """Handle self-closing tags like <img ... />."""
+        self.handle_starttag(tag, attrs)
+
 def map_url_to_file(url: str):
     if not url.startswith('/'):
         return None


### PR DESCRIPTION
## Summary

- What does this PR change and why?

## Changes

- Key updates (files, features, fixes)

## Screenshots / Demos (optional)

- Add before/after or a short clip if helpful

## Checklist

- [ ] Ran `bundle install` (if Gemfile changed)
- [ ] Previewed locally with `bundle exec jekyll serve`
- [ ] Checked `/tumbling/` shows the expected thumbnail(s)
- [ ] Image paths use leading slash (e.g., `/assets/tumbling/<id>/after-s4.jpg`)
- [ ] No zero‑byte images (opened locally to verify)
- [ ] Front matter has required fields (`batch`, `status`, `date_started`, `stages`)
- [ ] Added `images.rough` (Before Tumbling) where available
- [ ] Added most recent stage image(s); `images.after_burnish` if finished
- [ ] Updated docs when behavior changed (`.bundle/CONTRIBUTING.md`)
 - [ ] Reviewed auto-generated summaries:
   - “Change Summary” check in the Checks tab
   - PR comment labeled “changes-summary” (auto-updates on push)

## Notes for reviewers (optional)

- Special considerations, migration notes, or follow‑ups

## Auto Summary

The bot posts a “Change Summary” check and an auto-updating PR comment listing commits and files changed. Use those for quick context when reviewing.
