### PR TITLE
Field log updater: allow camera roll selection

### DIFF
--- a/_admin/field-log.html
+++ b/_admin/field-log.html
@@ -79,8 +79,8 @@ permalink: /admin/field-log/
   </div>
 
   <div class="grid-2" style="align-items:end">
-    <label>Choose close-up image (camera OK)
-      <input id="fld-file-close" type="file" accept="image/*" capture="environment">
+    <label>Choose close-up image (camera or gallery)
+      <input id="fld-file-close" type="file" accept="image/*">
     </label>
     <div class="actions">
       <button id="btn-upload-close" type="button">Upload Close-up → assets</button>
@@ -90,7 +90,7 @@ permalink: /admin/field-log/
 
   <div class="grid-2" style="align-items:end">
     <label>Choose scale image (optional)
-      <input id="fld-file-scale" type="file" accept="image/*" capture="environment">
+      <input id="fld-file-scale" type="file" accept="image/*">
     </label>
     <div class="actions">
       <button id="btn-upload-scale" type="button">Upload Scale → assets</button>
@@ -100,7 +100,7 @@ permalink: /admin/field-log/
 
   <div class="grid-2" style="align-items:end">
     <label>Pick a photo to read EXIF GPS
-      <input id="fld-photo-file" type="file" accept="image/*" capture="environment">
+      <input id="fld-photo-file" type="file" accept="image/*">
     </label>
     <div class="actions">
       <button type="button" id="btn-exif">Extract GPS</button>


### PR DESCRIPTION
## Summary
- allow selecting images from camera roll in admin field log uploader by removing the `capture` restriction

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done`
- `for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /Content-Type/p; /Content-Length/p'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bde024c2ac8326a66fa0abc0ef3c02