### PR TITLE
Rockhounding 101: adopt British spelling for colours

### DIFF
--- a/_notes/rockhounding/guides/Rockhounding 101.md
+++ b/_notes/rockhounding/guides/Rockhounding 101.md
@@ -35,7 +35,7 @@ The shores of Lake Ontario, shaped by glaciers and erosion, offer a treasure tro
     
 - **Search zones:** Look at pebble lines along the water’s edge, especially near **creek mouths**.
     
-- **Do the wet test:** Dip stones in water—colors and banding pop when wet.
+- **Do the wet test:** Dip stones in water—colours and banding pop when wet.
     
 - **Respect nature:** Follow conservation rules, and don’t collect from protected areas.
 
@@ -45,7 +45,7 @@ The shores of Lake Ontario, shaped by glaciers and erosion, offer a treasure tro
 
 - **[[agate|Agates]]:** Look for translucency and banding (hold to light).
     
-- **[[jasper]]:** Opaque, solid colors—reds and greens are most common.
+- **[[jasper]]:** Opaque, solid colours—reds and greens are most common.
     
 - **[[quartz|Quartz]]:** Glassy appearance, hardness test scratches glass.
     


### PR DESCRIPTION
## Summary
- Switch wet test and jasper descriptions to use British spelling "colours".

## Testing
- `python -m pytest -q`
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done`
- `for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /[Cc]ontent-[Tt]ype/p; /[Cc]ontent-[Ll]ength/p'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c4e7af483269b0d4c01db9b34de