### PR TITLE
Replace custom content tags with semantic elements

### DIFF
--- a/_includes/link-previews.html
+++ b/_includes/link-previews.html
@@ -39,7 +39,10 @@
         iframe.onload = function() {
           tooltipContentHtml = ''
           tooltipContentHtml += '<div class="lp-title">' + iframe.contentWindow.document.querySelector('h1').innerHTML + '</div>'
-          tooltipContentHtml += iframe.contentWindow.document.querySelector('content').innerHTML
+          var previewSource = iframe.contentWindow.document.querySelector('.page-content, .note-content');
+          if (previewSource) {
+            tooltipContentHtml += previewSource.innerHTML
+          }
 
           tooltipContent.innerHTML = tooltipContentHtml
           linkHistories[event.target.href] = tooltipContentHtml

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,8 +9,9 @@
       <footer>{% include footer.html %}</footer>
     </div>
 
-    {% include link-previews.html wrapperQuerySelector="content" %}
-    {% include link-previews.html wrapperQuerySelector="side" %}
+    {% include link-previews.html wrapperQuerySelector=".page-content" %}
+    {% include link-previews.html wrapperQuerySelector=".note-content" %}
+    {% include link-previews.html wrapperQuerySelector=".note-aside" %}
 
     <script>
       // Remove inputs injected by writing-aid browser extensions (e.g., ProWritingAid/Grammarly)

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -12,14 +12,14 @@ layout: default
   </div>
 
   <div id="notes-entry-container">
-    <content>
+    <div class="note-content">
       {{ content }}
-      
-      <p>     ┬─┬ノ( º _ ºノ)     </p>
-      
-    </content>
 
-    <side class="note-aside">
+      <p>     ┬─┬ノ( º _ ºノ)     </p>
+
+    </div>
+
+    <aside class="note-aside">
       <h3 class="backlinks-title">Notes mentioning this note</h3>
       {% if page.backlinks.size > 0 %}
       <ul class="backlinks">
@@ -33,7 +33,7 @@ layout: default
       {% else %}
       <div class="backlinks-empty">There are no notes linking to this note.</div>
       {% endif %}
-    </side>
+    </aside>
   </div>
 </article>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<content>
+<div class="page-content">
   {{ content }}
-</content>
+</div>


### PR DESCRIPTION
## Summary
- swap `<content>` and `<side>` tags in note and page layouts for standard `<div>` and `<aside>` containers
- update link preview selectors and script to target new classes
- add link preview support for main content and note asides

## Testing
- `bundle install`
- `bundle exec jekyll build`
- `ruby scripts/check_assets.rb`
- `python3 scripts/check_site_links.py`
- `bundle exec rake test`
- `curl -s -o /dev/null -w "%{http_code}" https://spectrumsyntax.netlify.app/`

------
https://chatgpt.com/codex/tasks/task_e_68bd1aaec5d0832681651046349a55e9