### PR TITLE
Notes layout: map grid areas

### DIFF
--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -12,14 +12,14 @@ layout: default
   </div>
 
   <div id="notes-entry-container">
-    <content>
+    <div class="content-section">
       {{ content }}
-      
-      <p>     ┬─┬ノ( º _ ºノ)     </p>
-      
-    </content>
 
-    <side class="note-aside">
+      <p>     ┬─┬ノ( º _ ºノ)     </p>
+
+    </div>
+
+    <aside class="note-aside">
       <h3 class="backlinks-title">Notes mentioning this note</h3>
       {% if page.backlinks.size > 0 %}
       <ul class="backlinks">
@@ -33,7 +33,7 @@ layout: default
       {% else %}
       <div class="backlinks-empty">There are no notes linking to this note.</div>
       {% endif %}
-    </side>
+    </aside>
   </div>
 </article>
 

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -413,6 +413,9 @@ a.internal-link:hover {
     grid-template-columns: 3fr 1fr;
     grid-template-areas: "content side";
   }
+
+  > .content-section { grid-area: content; }
+  > .note-aside { grid-area: side; }
 }
 
 /* .backlink-box removed; backlinks now flow like regular content */


### PR DESCRIPTION
## Summary
- Assign grid areas to note content and sidebar for responsive layout
- Replace custom `<content>`/`<side>` tags with semantic div/aside elements

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*
- `curl -s -o /dev/null -w "%{http_code}" "$BASE$p"` for key pages and assets

------
https://chatgpt.com/codex/tasks/task_e_68bd1ab1b7888326b489c7109c819b9b