### PR TITLE
CSS: adopt border-box globally

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -125,8 +125,11 @@ html {
   /* Additive bump: increase base font size by 1pt site-wide */
   font-size: calc(100% + 1pt);
 }
+*, *::before, *::after {
+  box-sizing: inherit;
+}
 body {
-  box-sizing: content-box;
+  box-sizing: border-box;
   font-family: $font-family;
   margin: 0 auto;
   line-height: 1.7;


### PR DESCRIPTION
## Summary
- cascade border-box sizing from the body and child elements

## Testing
- `bundle exec rake`
- `pytest tests`
- `bundle exec jekyll build`
- `curl -s -o /dev/null -w "%{http_code}" https://spectrumsyntax.netlify.app/` (and other key pages and assets)

------
https://chatgpt.com/codex/tasks/task_e_68bd1ab35724832686b1185e692d2cae