### PR TITLE
style: allow horizontal scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog and the project attempts to adhere to Se
 
 ## [Unreleased]
 
+### Changed
+- Remove global `overflow-x: hidden` from body to allow horizontal scrolling for wide content.
+
 ## [0.2.0] - 2025-09-02
 
 ### Added

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -131,7 +131,7 @@ body {
   margin: 0 auto;
   line-height: 1.7;
   padding: 4vh 6vw;
-  overflow-x: hidden;
+  // overflow-x: hidden;  // allow horizontal scroll; contain overflow per component
   color: var(--color-text);
   font-size: 1rem;
   max-width: 63em;


### PR DESCRIPTION
## Summary
- remove body `overflow-x: hidden` so wide content can scroll horizontally
- document the change in `CHANGELOG.md`

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*
- `curl https://spectrumsyntax.netlify.app/`
- `curl https://spectrumsyntax.netlify.app/rockhounding/`
- `curl https://spectrumsyntax.netlify.app/logs/`
- `curl https://spectrumsyntax.netlify.app/rockhounding/tumbling/`
- `curl https://spectrumsyntax.netlify.app/rockhounding/field-log/`
- `curl -I https://spectrumsyntax.netlify.app/assets/rockhounding/thumbs/rocks-and-minerals.webp`
- `curl -I https://spectrumsyntax.netlify.app/assets/rockhounding/thumbs/guides.webp`


------
https://chatgpt.com/codex/tasks/task_e_68bd1ab4cedc83269b5ba3945772d400