### PR TITLE
IDLE Champions: use British spelling

### DIFF
--- a/_notes/Games/IDLE Champions/IDLE Champions.md
+++ b/_notes/Games/IDLE Champions/IDLE Champions.md
@@ -3,7 +3,7 @@ title: IDLE Champions
 draft:
 aliases:
 ---
-An idle/formation RPG set in D&D’s Forgotten Realms. It’s **playable F2P** but built for long-tail grind: real progress comes from event cycles, gem farming, and optimizing formations; late-game goals can take **thousands of hours** without spending. Monetization centers on chests, DLC packs, “weekend” offers, and familiars (QoL that speeds everything up). It’s not hard P2W—money mostly accelerates unlocks and gearing—but it can be **aggressively tempting** if you chase every champion/skin/GE. Longevity is strong: the devs keep adding events, variants, and even new (paid) chest tiers like Platinum packs. Verdict: **fun for systems/optimization fans with high tolerance for grind;** excellent background game if you enjoy steady incremental goals, less so if you want rapid traditional RPG payoff.
+An idle/formation RPG set in D&D’s Forgotten Realms. It’s **playable F2P** but built for long-tail grind: real progress comes from event cycles, gem farming, and optimizing formations; late-game goals can take **thousands of hours** without spending. Monetization centres on chests, DLC packs, “weekend” offers, and familiars (QoL that speeds everything up). It’s not hard P2W—money mostly accelerates unlocks and gearing—but it can be **aggressively tempting** if you chase every champion/skin/GE. Longevity is strong: the devs keep adding events, variants, and even new (paid) chest tiers like Platinum packs. Verdict: **fun for systems/optimization fans with high tolerance for grind;** excellent background game if you enjoy steady incremental goals, less so if you want rapid traditional RPG payoff.
 
 ## Guides
 [[Into the Forbidden Zone]]


### PR DESCRIPTION
## Summary
- Prefer "centres" to US spelling in IDLE Champions note

## Testing
- `bundle _2.7.1_ exec rake test`
- `for p in / \"/rockhounding/\" \"/logs/\" \"/rockhounding/tumbling/\" \"/rockhounding/field-log/\"; do code=$(curl -s -o /dev/null -w "%{http_code}" "https://spectrumsyntax.netlify.app$p"); echo "$p -> $code"; done`
- `for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "https://spectrumsyntax.netlify.app$a" | grep -i -E '^(HTTP|content-type|content-length)'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c5213d08326990e52e48d7ad13a