### PR TITLE
IDLE Champions: adopt British spelling

### DIFF
--- a/_notes/Games/IDLE Champions/IDLE Gold Farming.md
+++ b/_notes/Games/IDLE Champions/IDLE Gold Farming.md
@@ -165,7 +165,7 @@ _(Full table in original guide — exceptions apply!)_
     
     1. High BUD formation with tanks holding ~100 enemies.
         
-    2. Gold Find formation centered on **Makos** (_Dark Luck specialization_).
+    2. Gold Find formation centred on **Makos** (_Dark Luck specialization_).
         
 - Fire Makos’ Ultimate into the stack for massive gold.
     
@@ -235,7 +235,7 @@ _(Full table in original guide — exceptions apply!)_
 
 ## 📍 Best Farming Locations by Campaign
 
-Choose **adventures/Free Plays without armored bosses**.
+Choose **adventures/Free Plays without armoured bosses**.
 
 |Campaign|Example Adventure|
 |---|---|
@@ -261,4 +261,4 @@ Choose **adventures/Free Plays without armored bosses**.
     
 
 **Good luck & have fun!**  
-~ Gaar
+~ Gaarawarr


### PR DESCRIPTION
## Summary
- Use British spelling in Makos formation description and gold farming location tips
- Restore closing signature line in the Gold Farming guide

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*
- `curl -s -o /dev/null -w "%{http_code}" "$BASE$p"` for key pages
- `curl -sI "$BASE$a"` for example assets

------
https://chatgpt.com/codex/tasks/task_e_68bd1c543c74832696406f3a93aa98a8