### PR TITLE
Rock note: use grey spelling

### DIFF
--- a/_notes/rockhounding/rocks/sedimentary/banded-iron-formation.md
+++ b/_notes/rockhounding/rocks/sedimentary/banded-iron-formation.md
@@ -2,9 +2,9 @@
 title: Banded Iron Formation
 layout: note
 thumbnail: https://upload.wikimedia.org/wikipedia/commons/2/25/Banded_iron_formation_Dales_Gorge.jpg
-description: Banded iron formation is a Precambrian sedimentary rock of alternating iron‑rich layers (hematite or magnetite) and silica (chert), typically showing red and gray bands.
+description: Banded iron formation is a Precambrian sedimentary rock of alternating iron‑rich layers (hematite or magnetite) and silica (chert), typically showing red and grey bands.
 hardness: "≈5.5–7"
 ---
 {% include rock-card.html rock=page %}
 
-Banded iron formation is a Precambrian sedimentary rock of alternating iron‑rich layers (hematite or magnetite) and silica (chert), typically showing red and gray bands.
+Banded iron formation is a Precambrian sedimentary rock of alternating iron‑rich layers (hematite or magnetite) and silica (chert), typically showing red and grey bands.


### PR DESCRIPTION
## Summary
- Use "grey" instead of "gray" for the Banded Iron Formation note

## Testing
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1 and other gems)*
- `pytest tests/test_git_push.py`
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done; for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /Content-Type/p; /Content-Length/p'; done`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c5a467c83268561018fc97ddc3d