### PR TITLE
docs: adopt British spelling in red jasper field log

### DIFF
--- a/_notes/rockhounding/field-log/2025-09-06-red-jasper.md
+++ b/_notes/rockhounding/field-log/2025-09-06-red-jasper.md
@@ -26,7 +26,7 @@ gallery:
   - { src: "/assets/Rockhound - 4 of 4.jpeg", caption: "Colour under diffuse light" }
 ---
 
-Collected along the wave‑polished pebble line. The piece shows uniform deep red coloration with occasional darker mottling, consistent with hematite inclusions in chalcedony. Fresh chip displays a clean conchoidal fracture and vitreous luster.
+Collected along the wave‑polished pebble line. The piece shows uniform deep red colouration with occasional darker mottling, consistent with hematite inclusions in chalcedony. Fresh chip displays a clean conchoidal fracture and vitreous lustre.
 
 Field tests: copper does not scratch; scratches glass; white streak on unglazed porcelain. Identification consistent with red jasper (a variety of microcrystalline quartz).
 


### PR DESCRIPTION
## Summary
- use British spellings for colouration and lustre in the red jasper field log

## Testing
- `bundle exec jekyll build --quiet`
- `ruby scripts/check_assets.rb`
- `python3 scripts/check_site_links.py` *(fails: broken references found)*
- `bundle exec rake test`
- live URL and asset checks via curl

------
https://chatgpt.com/codex/tasks/task_e_68bd1c5bd2c483269f1bf5123a5554c6