### PR TITLE
Notes: British spelling in Into the Forbidden Zone

### DIFF
--- a/_notes/Games/Dark War Survival/Into the Forbidden Zone.md
+++ b/_notes/Games/Dark War Survival/Into the Forbidden Zone.md
@@ -55,7 +55,7 @@ In play, you build/upgrade turrets and basic income sources to survive waves; ea
 
 ## General Tips
 
-- Focus on **economy → defense → reactive reinforcement**.
+- Focus on **economy → defence → reactive reinforcement**.
 - Avoid overspending; only upgrade what’s necessary for the stage.
 - Watch [[zombies]] movement and adjust your layout or upgrade timing.
 


### PR DESCRIPTION
## Summary
- Use British spelling "defence" in Dark War Survival's Into the Forbidden Zone note

## Testing
- `pytest`
- `bundle exec rake` *(fails: Could not find nokogiri-1.18.9)*
- quick check of key pages and assets

------
https://chatgpt.com/codex/tasks/task_e_68bd1c587148832684506394bc0d20fd