### PR TITLE
Tumbling log: use British behaviour spelling

### DIFF
--- a/_pages/tumbling/log-checklist.md
+++ b/_pages/tumbling/log-checklist.md
@@ -58,7 +58,7 @@ Provide the following for each stage you run. Stages are typically 1–5.
 - [ ] Maintenance (optional)
   - [ ] `maintenance` — top-ups, checks, leak/foam notes
 - [ ] Observations
-  - [ ] `observations` — what you saw, issues, rock behavior
+  - [ ] `observations` — what you saw, issues, rock behaviour
 - [ ] Decision block (optional but helpful)
   - [ ] `decision.repeat` — `yes` | `no`
   - [ ] `decision.why` — short reason


### PR DESCRIPTION
## Summary
- fix spelling in tumbling log checklist to use "behaviour"

## Testing
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1 and other gems)*
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done; for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /Content-Type/p; /Content-Length/p'; done`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c5da82c83269710cbddc5a8fe78