### PR TITLE
docs: use British spelling for template behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To host the site elsewhere, run `bundle exec jekyll build` and upload the genera
 - Netlify build
   - Netlify runs the WebP step automatically before building Jekyll (`bundle exec rake webp && bundle exec jekyll build --trace`).
 
-- Template behavior
+- Template behaviour
   - Templates prefer WebP for local images via a `<picture>` source and fall back to the original JPEG/PNG.
   - External images (e.g., Wikimedia) are used as-is.
 


### PR DESCRIPTION
## Summary
- adopt British spelling for template behaviour in README

## Testing
- `bundle exec rake test`
- `BASE="https://spectrumsyntax.netlify.app"` pages and assets respond with HTTP 200

------
https://chatgpt.com/codex/tasks/task_e_68bd1c5fe5a483269d2de0ad8771aabe