### PR TITLE
Rockhounding: use British spelling for Puddingstone

### DIFF
--- a/_notes/rockhounding/rocks/sedimentary/conglomerate.md
+++ b/_notes/rockhounding/rocks/sedimentary/conglomerate.md
@@ -12,6 +12,6 @@ hardness: "≈2–7"
 ---
 {% include rock-card.html rock=page %}
 
-Conglomerate is a clastic sedimentary rock of rounded pebbles and cobbles set in a finer matrix; the rounded clasts record transport by water. “Puddingstone” is a colorful variety.
+Conglomerate is a clastic sedimentary rock of rounded pebbles and cobbles set in a finer matrix; the rounded clasts record transport by water. “Puddingstone” is a colourful variety.
 
 Related: [[Jasper]], [[Quartz]]


### PR DESCRIPTION
## Summary
- use "colourful" in Puddingstone note for consistent British spelling

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9 in locally installed gems)*
- `for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "https://spectrumsyntax.netlify.app$p"); echo "$p -> $code"; done`
- `for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "https://spectrumsyntax.netlify.app$a" | sed -n '1p; /Content-Type/p; /Content-Length/p'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c64b54c8326b347dd5a58cc9348