### PR TITLE
Amethyst: adopt British spelling for coloured

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/amethyst.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/amethyst.md
@@ -8,4 +8,4 @@ streak: White
 ---
 {% include rock-card.html rock=page %}
 
-Amethyst is purple quartz colored by trace iron and natural irradiation; crystals often line volcanic cavities and geodes.
+Amethyst is purple quartz coloured by trace iron and natural irradiation; crystals often line volcanic cavities and geodes.


### PR DESCRIPTION
## Summary
- use British spelling "coloured" in amethyst note

## Testing
- `ruby scripts/check_assets.rb`
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1, jekyll-sass-converter-3.0.0, sass-embedded-1.71.1, google-protobuf-3.25.8, bigdecimal-3.1.9, jekyll-last-modified-at-1.3.2, webrick-1.9.1, nokogiri-1.18.9, json-2.13.2, minitest-5.25.5, addressable-2.8.7, em-websocket-0.5.3, i18n-1.14.7, jekyll-watch-2.2.1, kramdown-2.5.1, kramdown-parser-gfm-1.1.0, liquid-4.0.4, mercenary-0.4.0, pathutil-0.16.2, rouge-4.5.1, safe_yaml-1.0.5, terminal-table-3.0.2, mini_portile2-2.8.9, racc-1.8.1, eventmachine-1.2.7, listen-3.9.0, rexml-3.4.0, unicode-display_width-2.6.0, rb-fsevent-0.11.2, rb-inotify-0.11.1, ffi-1.17.1)*
- `python3 scripts/check_site_links.py` *(fails: _site not found. Build the site first: bundle exec jekyll build)*
- `curl -s -o /dev/null -w "%{http_code}" "$BASE$p"`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c68a4048326a06ad8288c285e53