### PR TITLE
Use British spelling for colour in Garnet note

### DIFF
--- a/_notes/rockhounding/rocks/minerals/garnet.md
+++ b/_notes/rockhounding/rocks/minerals/garnet.md
@@ -58,4 +58,4 @@ streak: White
   </div>
 {%- endif -%}
 
-Garnet is a group of silicate minerals common in metamorphic rocks; it typically forms dodecahedral crystals and ranges in color from deep red to green.
+Garnet is a group of silicate minerals common in metamorphic rocks; it typically forms dodecahedral crystals and ranges in colour from deep red to green.


### PR DESCRIPTION
## Summary
- switch Garnet note to British "colour" spelling

## Testing
- `bundle _2.7.1_ exec rake test`
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done; for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /Content-Type/p; /Content-Length/p'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c6a38448326aabd06e88b90a2c6