### PR TITLE
Use British spelling for Aventurine description

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/aventurine.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/aventurine.md
@@ -8,4 +8,4 @@ streak: White
 ---
 {% include rock-card.html rock=page %}
 
-Aventurine is a variety of quartz containing shimmering inclusions (commonly mica or fuchsite) that create a sparkly effect; green is the most typical color.
+Aventurine is a variety of quartz containing shimmering inclusions (commonly mica or fuchsite) that create a sparkly effect; green is the most typical colour.


### PR DESCRIPTION
## Summary
- use British spelling "colour" in Aventurine description

## Testing
- `bundle exec rake test`
- `curl -s -o /dev/null -w "%{http_code}" https://spectrumsyntax.netlify.app/rockhounding/rocks/minerals/quartz/aventurine/`
- `curl -sI https://spectrumsyntax.netlify.app/assets/rockhounding/thumbs/rocks-and-minerals.webp`
- `curl -sI https://spectrumsyntax.netlify.app/assets/rockhounding/thumbs/guides.webp`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c6db99083268749684cc3715c35