### PR TITLE
Lake Superior agate: use colour spelling

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/lake-superior-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/lake-superior-agate.md
@@ -8,4 +8,4 @@ luster: null
 ---
 {% include rock-card.html rock=page %}
 
-Lake Superior agate is an iron‑rich banded agate from the Great Lakes region; red‑orange bands get their color from hematite.
+Lake Superior agate is an iron‑rich banded agate from the Great Lakes region; red‑orange bands get their colour from hematite.


### PR DESCRIPTION
## Summary
- correct Lake Superior agate description to use "colour" spelling

## Testing
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "https://spectrumsyntax.netlify.app$p"); echo "$p -> $code"; done`
- `for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "https://spectrumsyntax.netlify.app$a" | grep -i -E '^(HTTP|content-type|content-length)'; echo; done`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c70403c8326a7ed0bb4b9c7b18d