### PR TITLE
Rose quartz: switch to British spelling

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/rose-quartz.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/rose-quartz.md
@@ -8,4 +8,4 @@ streak: White
 ---
 {% include rock-card.html rock=page %}
 
-Rose quartz is pink quartz colored by trace impurities and fibrous inclusions; it is typically massive rather than well‑crystallized.
+Rose quartz is pink quartz coloured by trace impurities and fibrous inclusions; it is typically massive rather than well‑crystallized.


### PR DESCRIPTION
## Summary
- fix rose quartz description to use British English spelling

## Testing
- `bundle exec rake` *(fails: Could not find nokogiri-1.18.9)*
- `for p in / \ /rockhounding/ \ /logs/ \ /rockhounding/tumbling/ \ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done; for a in \ /assets/rockhounding/thumbs/rocks-and-minerals.webp \ /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /[Cc]ontent-[Tt]ype/p; /[Cc]ontent-[Ll]ength/p'; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1c73c67c8326beb53bde9e505064