### PR TITLE
Coldwater agate: use British spelling for banding colours

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/coldwater-agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/coldwater-agate.md
@@ -10,4 +10,4 @@ streak: White
 ---
 {% include rock-card.html rock=page %}
 
-Coldwater agate forms in sedimentary rocks from low‑temperature silica solutions; banding tends to be subtle with earthy colors.
+Coldwater agate forms in sedimentary rocks from low‑temperature silica solutions; banding tends to be subtle with earthy colours.


### PR DESCRIPTION
## Summary
- use British spelling for "colours" in Coldwater agate description

## Testing
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1...)*
- `pytest tests`
- `curl https://spectrumsyntax.netlify.app{/,/rockhounding/,/logs/,/rockhounding/tumbling/,/rockhounding/field-log/}`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c77f84483268dda4b8ccc37d43b