### PR TITLE
Agate note: use British spelling for band colour

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/index.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/index.md
@@ -8,4 +8,4 @@ luster: null
 ---
 {% include rock-card.html rock=page %}
 
-Agate is banded chalcedony formed as silica layers deposit in cavities; its concentric bands display wide color and pattern variation.
+Agate is banded chalcedony formed as silica layers deposit in cavities; its concentric bands display wide colour and pattern variation.


### PR DESCRIPTION
## Summary
- Use "colour" instead of "color" in the agate banding description.

## Testing
- `bundle exec jekyll build` *(fails: Could not find nokogiri-1.18.9)*
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done`
- `BASE="https://spectrumsyntax.netlify.app"; for a in /assets/rockhounding/thumbs/rocks-and-minerals.webp /assets/rockhounding/thumbs/guides.webp; do echo -n "$a -> "; curl -sI "$BASE$a" | sed -n '1p; /[Cc]ontent-[Tt]ype/p; /[Cc]ontent-[Ll]ength/p'; done`
- `curl -s -o /tmp/agate.html -w "%{http_code}\n" "https://spectrumsyntax.netlify.app/rockhounding/rocks/minerals/quartz/chalcedony/agate/"` *(404)*


------
https://chatgpt.com/codex/tasks/task_e_68bd1c7ca5b08326bd0129b8d2613820