### PR TITLE
Agate: use UK spelling for colours

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/agate.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/chalcedony/agate/agate.md
@@ -15,6 +15,6 @@ streak: White
 ---
 {% include rock-card.html rock=page %}
 
-Agate is banded chalcedony that forms when silica‑rich fluids deposit layers of microcrystalline quartz in cavities; banding reveals varied colors and patterns.
+Agate is banded chalcedony that forms when silica‑rich fluids deposit layers of microcrystalline quartz in cavities; banding reveals varied colours and patterns.
 
 Related: [[Chalcedony]], [[Jasper]]


### PR DESCRIPTION
## Summary
- use UK spelling for banding colours in Agate note

## Testing
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1... Bundler::GemNotFound)*
- `for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "https://spectrumsyntax.netlify.app$p"); echo "$p -> $code"; done`
- `curl -sI https://spectrumsyntax.netlify.app/assets/rockhounding/thumbs/rocks-and-minerals.webp`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c7ef6508326957b66ba900b1a1c