### PR TITLE
Jasper: use British colour spelling

### DIFF
--- a/_notes/rockhounding/rocks/minerals/quartz/jasper/index.md
+++ b/_notes/rockhounding/rocks/minerals/quartz/jasper/index.md
@@ -9,4 +9,4 @@ thumbnail: "https://upload.wikimedia.org/wikipedia/commons/1/14/Unpolished_jaspe
 
 {% include rock-card.html rock=page %}
 
-Jasper is an opaque, iron‑bearing form of microcrystalline quartz; this section groups its many color and pattern varieties.
+Jasper is an opaque, iron‑bearing form of microcrystalline quartz; this section groups its many colour and pattern varieties.


### PR DESCRIPTION
## Summary
- tweak Jasper variety description to use British "colour" spelling

## Testing
- `ruby scripts/check_assets.rb`
- `python3 scripts/check_site_links.py` *(fails: `_site` not found)*
- `bundle exec rake test` *(fails: Could not find nokogiri-1.18.9)*
- `curl -s -o /dev/null -w "%{http_code}" https://spectrumsyntax.netlify.app/...`

------
https://chatgpt.com/codex/tasks/task_e_68bd1c80ca64832699d161714cffcca5