### PR TITLE
README: drop WebP step from local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ This project targets Ruby 3.2.1 and Bundler 2.7.1. On macOS, use rbenv for a smo
 
 4) Build or serve the site locally:
    ```bash
-   # Optional: generate WebP for local images (faster loads)
-   bundle exec rake webp
    bundle exec jekyll serve
    # or
    bundle exec jekyll build


### PR DESCRIPTION
## Summary
- remove optional WebP generation from local setup instructions, retaining separate Images and WebP section

## Testing
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1...)*
- `BASE="https://spectrumsyntax.netlify.app"; for p in / /rockhounding/ /logs/ /rockhounding/tumbling/ /rockhounding/field-log/; do code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE$p"); echo "$p -> $code"; done`


------
https://chatgpt.com/codex/tasks/task_e_68bd1e1005e08326bd404aabd815748f