### PR TITLE
docs: refer readers to Git push helper for push commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,7 @@ This project targets Ruby 3.2.1 and Bundler 2.7.1. On macOS, use rbenv for a smo
    bundle exec rake test
    ```
 
-8) Push changes with the helper script:
-   ```bash
-   python3 git_push.py -m "Your message"
-   ```
-   See more options in the [Git push helper](#git-push-helper) section (includes IPv4/IPv6 flags for reliable SSH when iCloud Private Relay is enabled).
+For push commands, see the [Git push helper](#git-push-helper) section.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- drop push step from Local setup
- direct readers to Git push helper section for push commands

## Testing
- `bundle _2.7.1_ exec rake test`
- Verified live pages and assets return HTTP 200

------
https://chatgpt.com/codex/tasks/task_e_68bd1e1fd14c8326818b154f345012a8