### PR TITLE
README: fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ Use the repository’s helper script to stage, commit, rebase, and push with sen
 
 ## License
 
-Source code is available under the [MIT license](LICENSE.md).
+Source code is available under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary
- fix README license section to point to LICENSE file without extension

## Testing
- `pytest tests`
- `bundle exec rake test` *(fails: Could not find jekyll-4.4.1, jekyll-sass-converter-3.0.0, sass-embedded-1.71.1, google-protobuf-3.25.8, bigdecimal-3.1.9, jekyll-last-modified-at-1.3.2, webrick-1.9.1, nokogiri-1.18.9, json-2.13.2, minitest-5.25.5, addressable-2.8.7, base64-0.2.0, colorator-1.1.0, csv-3.3.2, em-websocket-0.5.3, i18n-1.14.7, jekyll-watch-2.2.1, kramdown-2.5.1, kramdown-parser-gfm-1.1.0, liquid-4.0.4, mercenary-0.4.0, pathutil-0.16.2, rouge-4.5.1, safe_yaml-1.0.5, terminal-table-3.0.2, rake-13.2.1, mini_portile2-2.8.9, racc-1.8.1, public_suffix-6.0.1, eventmachine-1.2.7, http_parser.rb-0.8.0, concurrent-ruby-1.3.5, listen-3.9.0, rexml-3.4.0, forwardable-extended-2.6.0, unicode-display_width-2.6.0, rb-fsevent-0.11.2, rb-inotify-0.11.1, ffi-1.17.1)`

------
https://chatgpt.com/codex/tasks/task_e_68bd1e4d14788326bafe49ddc4923bf5