### PR TITLE
Optimize bidirectional link detection and tests

### DIFF
--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -24,121 +24,72 @@ class BidirectionalLinksGenerator < Jekyll::Generator
 
     backlinks_by_target = Hash.new { |h, k| h[k] = Set.new }
 
+    link_candidates = {}
+
+    all_docs.each do |doc|
+      base = File.basename(doc.basename, File.extname(doc.basename))
+      title_from_data = doc.data["title"]
+      raw_aliases = doc.data["aliases"]
+      aliases_arr =
+        case raw_aliases
+        when String then [raw_aliases]
+        when Array then raw_aliases.compact.map(&:to_s)
+        else []
+        end
+
+      candidates = [{ value: base, flexible: true }]
+      candidates << { value: title_from_data, flexible: false } if title_from_data && !title_from_data.to_s.strip.empty?
+      candidates.concat(aliases_arr.map { |al| { value: al, flexible: true } })
+
+      candidates.each do |candidate|
+        normalized = normalize_link_text(candidate[:value])
+        next if normalized.empty? || link_candidates.key?(normalized)
+
+        link_candidates[normalized] = {
+          href: "#{site.baseurl}#{doc.url}#{link_extension}",
+          target_id: note_ids[doc],
+          pattern: candidate_pattern(candidate[:value], flexible: candidate[:flexible])
+        }
+      end
+    end
+
+    pattern_union = link_candidates.values.map { |data| "(?:#{data[:pattern]})" }.join("|")
+    combined_regex = pattern_union.empty? ? nil : /\[\[(#{pattern_union})(?:\|([^\]]+?))?\]\]/i
+
     # Convert [[Wiki-style]] links to <a> with class="internal-link"
     all_docs.each do |current_note|
-      original_content = current_note.content.to_s.dup
       source_is_note = all_notes.include?(current_note)
+      matched_targets = Set.new
 
-      all_docs.each do |note_potentially_linked_to|
-        # filename (without ext) pattern: allow "_" or "-" to be typed as space too
-        base = File.basename(
-          note_potentially_linked_to.basename,
-          File.extname(note_potentially_linked_to.basename)
-        )
-        base_rx = Regexp.escape(base).gsub('\_', '[ _]').gsub('\-', '[ -]')
+      if combined_regex
+        current_note.content = current_note.content.to_s.gsub(combined_regex) do
+          matched_text = Regexp.last_match(1)
+          label = Regexp.last_match(2) || matched_text
+          target = link_candidates[normalize_link_text(matched_text)]
 
-        # title pattern (if present)
-        title_from_data = note_potentially_linked_to.data["title"]
-        note_title_regexp_pattern =
-          if title_from_data && !title_from_data.to_s.strip.empty?
-            Regexp.escape(title_from_data.to_s)
-          else
-            nil
+          matched_targets.add(target[:target_id]) if target && target[:target_id]
+          "<a class='internal-link' href='#{target[:href]}'>#{label}</a>"
+        end
+      end
+
+      if source_is_note
+        sid = note_ids[current_note]
+        matched_targets.each do |tid|
+          next if tid.nil? || sid.nil? || tid == sid
+
+          key = "#{sid}->#{tid}"
+          unless edge_set.include?(key)
+            graph_edges << { source: sid, target: tid }
+            edge_set.add(key)
           end
-
-        # alias patterns (if present) — support [[alias]] and [[alias|label]]
-        raw_aliases = note_potentially_linked_to.data["aliases"]
-        aliases_arr =
-          case raw_aliases
-          when String then [raw_aliases]
-          when Array then raw_aliases.compact.map(&:to_s)
-          else []
-          end
-
-        new_href   = "#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}"
-        anchor_tag = "<a class='internal-link' href='#{new_href}'>\\1</a>"
-
-        if source_is_note && all_notes.include?(note_potentially_linked_to) && current_note != note_potentially_linked_to
-          sid = note_ids[current_note]
-          tid = note_ids[note_potentially_linked_to]
-          if sid && tid
-            matched = false
-            matched ||= original_content.match?(/\[\[(?:#{base_rx})(?:\|.+?)?\]\]/i)
-            if !matched && note_title_regexp_pattern
-              matched ||= original_content.match?(/\[\[(?:#{note_title_regexp_pattern})(?:\|.+?)?\]\]/i)
-            end
-            if !matched && !aliases_arr.empty?
-              aliases_arr.each do |al|
-                next if al.to_s.strip.empty?
-                al_rx = Regexp.escape(al.to_s).gsub('\_', '[ _]').gsub('\-', '[ -]')
-                if original_content.match?(/\[\[(?:#{al_rx})(?:\|.+?)?\]\]/i)
-                  matched = true
-                  break
-                end
-              end
-            end
-
-            if matched
-              key = "#{sid}->#{tid}"
-              unless edge_set.include?(key)
-                graph_edges << { source: sid, target: tid }
-                edge_set.add(key)
-              end
-              backlinks_by_target[tid].add(sid)
-            end
-          end
+          backlinks_by_target[tid].add(sid)
         end
-
-        # [[filename|label]]
-        current_note.content.gsub!(
-          /\[\[(?:#{base_rx})\|(.+?)(?=\])\]\]/i,
-          anchor_tag
-        )
-
-        # [[title|label]]
-        if note_title_regexp_pattern
-          current_note.content.gsub!(
-            /\[\[(?:#{note_title_regexp_pattern})\|(.+?)(?=\])\]\]/i,
-            anchor_tag
-          )
-        end
-
-        # [[title]]
-        if note_title_regexp_pattern
-          current_note.content.gsub!(
-            /\[\[(#{note_title_regexp_pattern})\]\]/i,
-            anchor_tag
-          )
-        end
-
-        # [[alias|label]] and [[alias]]
-        aliases_arr.each do |al|
-          next if al.to_s.strip.empty?
-          al_rx = Regexp.escape(al.to_s).gsub('\_', '[ _]').gsub('\-', '[ -]')
-          current_note.content.gsub!(
-            /\[\[(?:#{al_rx})\|(.+?)(?=\])\]\]/i,
-            anchor_tag
-          )
-          current_note.content.gsub!(
-            /\[\[(#{al_rx})\]\]/i,
-            anchor_tag
-          )
-        end
-
-        # [[filename]]
-        current_note.content.gsub!(
-          /\[\[(#{base_rx})\]\]/i,
-          anchor_tag
-        )
       end
 
       # Remaining [[...]] → invalid-link spans
-      current_note.content = current_note.content.gsub(
-        /\[\[([^\]]+)\]\]/i,
-        <<~HTML.delete("\n")
-          <span title='Coming Soon™' class='invalid-link'>\\1</span>
-        HTML
-      )
+      current_note.content = current_note.content.gsub(/\[\[([^\]]+)\]\]/i) do
+        "<span title='Coming Soon™' class='invalid-link'>#{Regexp.last_match(1)}</span>"
+      end
     end
 
     # Backlinks + graph
@@ -225,5 +176,18 @@ class BidirectionalLinksGenerator < Jekyll::Generator
 
     return nil if title.nil? || title.to_s.strip.empty?
     title.to_s.bytes.join
+  end
+
+  private
+
+  def normalize_link_text(text)
+    text.to_s.downcase.gsub(/[ _-]+/, " ").strip
+  end
+
+  def candidate_pattern(text, flexible: false)
+    pattern = Regexp.escape(text.to_s)
+    return pattern unless flexible
+
+    pattern.gsub("\\_", "[ _]").gsub("\\-", "[ -]")
   end
 end

--- a/test/bidirectional_links_generator_test.rb
+++ b/test/bidirectional_links_generator_test.rb
@@ -1,0 +1,84 @@
+require 'minitest/autorun'
+require 'json'
+require 'ostruct'
+require 'jekyll'
+require_relative '../_plugins/bidirectional_links_generator'
+
+class BidirectionalLinksGeneratorTest < Minitest::Test
+  class FakeDoc
+    attr_accessor :content
+    attr_reader :basename, :url, :data, :path, :basename_without_ext
+
+    def initialize(basename:, url:, content:, data:, path:)
+      @basename = basename
+      @url = url
+      @content = content
+      @data = data
+      @path = path
+      @basename_without_ext = File.basename(basename, File.extname(basename))
+    end
+  end
+
+  def setup
+    @generator = BidirectionalLinksGenerator.new
+  end
+
+  def test_replaces_links_and_generates_backlinks_for_aliases_and_titles
+    alpha = build_doc(
+      basename: 'alpha.md',
+      url: '/alpha',
+      content: 'Link to [[Beta Alias]] and [[Gamma Title|custom label]] plus [[Unknown Target]].',
+      data: { 'title' => 'Alpha' }
+    )
+
+    beta = build_doc(
+      basename: 'beta-file.md',
+      url: '/beta',
+      content: '',
+      data: { 'title' => 'Beta File', 'aliases' => ['Beta Alias'] }
+    )
+
+    gamma = build_doc(
+      basename: 'gamma.md',
+      url: '/gamma',
+      content: '',
+      data: { 'title' => 'Gamma Title' }
+    )
+
+    site = OpenStruct.new(
+      baseurl: '',
+      config: {},
+      pages: [],
+      collections: { 'notes' => OpenStruct.new(docs: [alpha, beta, gamma]) }
+    )
+
+    @generator.generate(site)
+
+    assert_includes alpha.content, "<a class='internal-link' href='/beta'>Beta Alias</a>"
+    assert_includes alpha.content, "<a class='internal-link' href='/gamma'>custom label</a>"
+    assert_includes alpha.content, "<span title='Coming Soon™' class='invalid-link'>Unknown Target</span>"
+
+    assert_equal [alpha], beta.data['backlinks']
+    assert_equal [alpha], gamma.data['backlinks']
+
+    graph = JSON.parse(File.read('_includes/notes_graph.json'))
+    alpha_id = @generator.note_id_from_note(alpha)
+    beta_id = @generator.note_id_from_note(beta)
+    gamma_id = @generator.note_id_from_note(gamma)
+
+    assert_includes graph['edges'], { 'source' => alpha_id, 'target' => beta_id }
+    assert_includes graph['edges'], { 'source' => alpha_id, 'target' => gamma_id }
+  end
+
+  private
+
+  def build_doc(basename:, url:, content:, data: {}, path: nil)
+    FakeDoc.new(
+      basename: basename,
+      url: url,
+      content: content,
+      data: data,
+      path: path || "_notes/#{basename}"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- precompute link candidates and a combined regex to replace wiki links in one pass while recording backlinks
- preserve invalid link handling and graph generation while capturing matches for edges
- add unit coverage for alias and title linking/backlinks in the generator

## Testing
- bundle exec ruby -Itest test/bidirectional_links_generator_test.rb
- bundle exec ruby -Itest test/image_exists_filter_test.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f10a1fc0832688c502b84f650b41)