### PR TITLE
Improve notes graph styling and readability

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -75,6 +75,8 @@
       text: readCssVar("--graph-text", "#353b3c"),
       textMuted: readCssVar("--graph-text-muted", "rgba(53, 59, 60, 0.6)"),
       highlight: readCssVar("--graph-highlight", "#ffffff"),
+      labelBg: readCssVar("--graph-label-bg", "rgba(8, 9, 14, 0.72)"),
+      labelBorder: readCssVar("--graph-label-border", "rgba(255, 255, 255, 0.14)"),
     };
 
     const seasonForDate = (dateStr) => {
@@ -465,13 +467,57 @@
       const getRelatedSet = (node) => {
         if (!node) return null;
         const related = new Set([node.id]);
-        links.forEach((l) => {
-          const source = l.source;
-          const target = l.target;
-          if (source === node.id) related.add(target);
-          if (target === node.id) related.add(source);
-        });
-        return related;
+      links.forEach((l) => {
+        const source = l.source;
+        const target = l.target;
+        if (source === node.id) related.add(target);
+        if (target === node.id) related.add(source);
+      });
+      return related;
+    };
+
+      const drawRoundedRect = (x, y, w, h, r) => {
+        ctx.beginPath();
+        if (ctx.roundRect) {
+          ctx.roundRect(x, y, w, h, r);
+          return;
+        }
+        const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
+        ctx.moveTo(x + radius, y);
+        ctx.lineTo(x + w - radius, y);
+        ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+        ctx.lineTo(x + w, y + h - radius);
+        ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+        ctx.lineTo(x + radius, y + h);
+        ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+        ctx.lineTo(x, y + radius);
+        ctx.quadraticCurveTo(x, y, x + radius, y);
+      };
+
+      const drawLabel = (text, screenX, screenY, isActive) => {
+        const paddingX = 8;
+        const paddingY = 5;
+        const metrics = ctx.measureText(text);
+        const ascent = metrics.actualBoundingBoxAscent || 10;
+        const descent = metrics.actualBoundingBoxDescent || 2;
+        const textHeight = ascent + descent;
+        const boxWidth = metrics.width + paddingX * 2;
+        const boxHeight = textHeight + paddingY * 2;
+        const labelX = screenX + 10;
+        const labelY = Math.max(8, screenY - boxHeight - 6);
+
+        ctx.save();
+        ctx.textBaseline = "top";
+        ctx.globalAlpha = isActive ? 0.98 : 0.82;
+        ctx.fillStyle = colours.labelBg;
+        ctx.strokeStyle = colours.labelBorder;
+        ctx.lineWidth = 1;
+        drawRoundedRect(labelX, labelY, boxWidth, boxHeight, 8);
+        ctx.fill();
+        ctx.stroke();
+        ctx.fillStyle = colours.textMuted;
+        ctx.fillText(text, labelX + paddingX, labelY + paddingY);
+        ctx.restore();
       };
 
       const draw = () => {
@@ -529,7 +575,6 @@
 
         if (related || !focusNode) {
           ctx.font = options.font;
-          ctx.fillStyle = colours.textMuted;
           nodes.slice(0, options.labelLimit).forEach((n) => {
             if (activeNode) {
               if (!related || !related.has(n.id)) return;
@@ -540,9 +585,7 @@
             if (!label) return;
             const text = label.length > options.labelMax ? label.slice(0, options.labelMax - 3) + "..." : label;
             const screen = toScreen(n.x, n.y);
-            const screenX = screen.x;
-            const screenY = screen.y;
-            ctx.fillText(text, screenX + 8, screenY - 8);
+            drawLabel(text, screen.x, screen.y, !!activeNode);
           });
         }
       };

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -108,6 +108,10 @@ $color-box-background: mix($tiffany-blue, white, 92%); /* soft panel bg */
   --graph-text: #f6f2ea;
   --graph-text-muted: rgba(246, 242, 234, 0.7);
   --graph-highlight: #ffffff;
+  --graph-canvas-border: rgba(246, 242, 234, 0.18);
+  --graph-canvas-glow: rgba(249, 199, 79, 0.12);
+  --graph-label-bg: rgba(8, 9, 14, 0.72);
+  --graph-label-border: rgba(255, 255, 255, 0.14);
 }
 
 /* =========================
@@ -164,6 +168,10 @@ html[data-theme='dark'] {
   --graph-igneous: #dc322f;
   --graph-sedimentary: #b58900;
   --graph-metamorphic: #268bd2;
+  --graph-canvas-border: rgba(253, 246, 227, 0.22);
+  --graph-canvas-glow: rgba(38, 139, 210, 0.14);
+  --graph-label-bg: rgba(3, 9, 15, 0.72);
+  --graph-label-border: rgba(253, 246, 227, 0.18);
 }
 $border-radius: 4px;
 $font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif,
@@ -867,6 +875,19 @@ html[data-theme='dark'] .site-footer a.internal-link {
   min-height: 320px;
   height: 100%;
   overflow: hidden;
+  isolation: isolate;
+}
+
+.graph-canvas-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 18%, rgba(255, 255, 255, 0.08), transparent 32%),
+    radial-gradient(circle at 82% 12%, rgba(255, 255, 255, 0.06), transparent 26%),
+    radial-gradient(circle at 46% 82%, rgba(0, 0, 0, 0.22), transparent 45%);
+  mix-blend-mode: screen;
+  z-index: 1;
 }
 
 .graph-canvas {
@@ -877,6 +898,8 @@ html[data-theme='dark'] .site-footer a.internal-link {
   background-image: var(--graph-canvas-stars), var(--graph-canvas-gradient);
   background-blend-mode: soft-light;
   border-radius: 12px;
+  border: 1px solid var(--graph-canvas-border);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 0 28px var(--graph-canvas-glow);
 }
 
 .welcome-card {
@@ -1566,6 +1589,8 @@ html[data-theme='dark'] .chip {
   position: relative;
   display: flex;
   flex-direction: column;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(6px) saturate(110%);
 }
 .graph-card::after {
   content: "";
@@ -1593,6 +1618,8 @@ html[data-theme='dark'] .chip {
   margin: 0 0 0.5rem;
   padding-bottom: 0.25rem;
   border-bottom: 1px solid var(--panel-border);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), transparent);
+  padding-inline: 0.25rem;
 }
 .graph-title { margin: 0; font-size: .9em; font-weight: 600; color: var(--color-text); }
 .graph-card__caption {


### PR DESCRIPTION
## Summary
- add label background styling and rounded rect rendering for graph node captions to improve readability
- polish graph canvases and cards with glow, border, and background accents driven by new CSS variables
- expose theme-aware label and canvas colors to keep graph visuals cohesive across themes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f6a3c8a88326810a83a6dcdeda05)