### PR TITLE
Rebuild tags page into grouped cloud

### DIFF
--- a/_pages/tags/index.md
+++ b/_pages/tags/index.md
@@ -4,29 +4,37 @@ title: Tags
 summary: Tag index that groups notes by topic.
 permalink: /tags/
 ---
-{%- assign tag_list = "" -%}
 {%- assign tagged_docs = site.notes | where_exp: "n", "n.tags != nil" -%}
-{%- for doc in tagged_docs -%}
-  {%- for tag in doc.tags -%}
-    {%- assign tag_list = tag_list | append: tag | append: "," -%}
-  {%- endfor -%}
-{%- endfor -%}
-{%- assign tags = tag_list | split: "," | uniq | sort -%}
+{%- assign tag_graph = tagged_docs | build_note_tag_graph -%}
+{%- assign tag_nodes = tag_graph["tag_nodes"] -%}
 
-<p>Tags across notes.</p>
-
-{% for tag in tags %}
-  {%- assign tag_name = tag | downcase -%}
-  {%- if tag_name != "" -%}
-  <section id="{{ tag_name | slugify }}">
-    <h2>#{{ tag_name }}</h2>
-    <ul>
-      {%- for doc in tagged_docs -%}
-        {%- if doc.tags contains tag -%}
-        <li><a class="internal-link" href="{{ doc.url | relative_url }}">{{ doc.title }}</a></li>
-        {%- endif -%}
-      {%- endfor -%}
-    </ul>
-  </section>
+{%- assign max_count = 0 -%}
+{%- for tag in tag_nodes -%}
+  {%- if tag.count > max_count -%}
+    {%- assign max_count = tag.count -%}
   {%- endif -%}
+{%- endfor -%}
+{%- if max_count == 0 -%}
+  {%- assign max_count = 1 -%}
+{%- endif -%}
+
+{%- assign tag_groups = tag_nodes | group_by: "root" | sort: "name" -%}
+
+<p>Tags across notes, sized by how often they appear (including nested tags).</p>
+
+{% for group in tag_groups %}
+  <section class="tag-group" id="{{ group.name | slugify }}">
+    <h2>{{ group.name }}</h2>
+    <div class="tag-cloud">
+      {%- assign sorted_tags = group.items | sort_natural: "full_label" -%}
+      {%- for tag in sorted_tags -%}
+        {%- assign weight = (tag.count | times: 1.0) | divided_by: max_count -%}
+        <a class="tag-chip" id="{{ tag.slug }}" href="{{ tag.path }}" style="--tag-weight: {{ weight | default: 0 }};">
+          {{ tag.full_label }}
+          <span class="tag-chip__count" aria-hidden="true">{{ tag.count }}</span>
+          <span class="sr-only">({{ tag.count }} uses)</span>
+        </a>
+      {%- endfor -%}
+    </div>
+  </section>
 {% endfor %}

--- a/_plugins/notes_graph_helper.rb
+++ b/_plugins/notes_graph_helper.rb
@@ -26,7 +26,10 @@ module Jekyll
           tag_name = tag.to_s.downcase
           parent = nil
 
-          tag_name.split("/").each do |part|
+          parts = tag_name.split("/")
+          tag_root = parts.first
+
+          parts.each do |part|
             current = parent ? "#{parent}/#{part}" : part
             slug = Jekyll::Utils.slugify(current)
 
@@ -34,6 +37,8 @@ module Jekyll
               slug: slug,
               id: "tag-#{slug}",
               label: "##{part}",
+              full_label: current,
+              root: tag_root,
               count: 0,
               path: "#{tags_root}##{slug}",
               type: "tag"
@@ -70,7 +75,7 @@ module Jekyll
                             .map { |tag, note_id| { source: "tag-#{tag}", target: "note-#{note_id}" } }
 
       {
-        "tag_nodes" => sorted_tags.map { |node| node.reject { |key, _| key == :slug } },
+        "tag_nodes" => sorted_tags,
         "note_nodes" => note_nodes.values,
         "tag_edges" => filtered_tag_edges,
         "note_edges" => filtered_note_edges

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1648,6 +1648,15 @@ html[data-theme='dark'] .chip {
   gap: 0.4rem;
 }
 
+.tag-group {
+  margin: 1rem 0 1.5rem;
+}
+
+.tag-group h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.4rem;
+}
+
 .tag-cloud--compact .tag-chip {
   padding: 0.15rem 0.45rem;
 }
@@ -1655,12 +1664,17 @@ html[data-theme='dark'] .chip {
 .tag-chip {
   display: inline-flex;
   align-items: center;
+  gap: 0.25rem;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
   background: rgba(198, 199, 196, 0.45);
   border: 1px solid rgba(53, 59, 60, 0.2);
   color: var(--color-text);
   text-decoration: none;
+  --tag-weight: 0.45;
+  font-size: calc(0.95rem + 0.45rem * var(--tag-weight));
+  font-weight: calc(520 + 320 * var(--tag-weight));
+  line-height: 1.1;
 }
 html[data-theme='dark'] .tag-chip {
   background: #073642;
@@ -1674,6 +1688,11 @@ html[data-theme='dark'] .tag-chip {
 .tag-chip:hover {
   background: rgba(162, 153, 158, 0.35);
   color: var(--color-text) !important;
+}
+
+.tag-chip__count {
+  font-size: 0.82em;
+  opacity: 0.75;
 }
 
 #graph-wrapper {


### PR DESCRIPTION
## Summary
- replace the tags index with a grouped tag cloud sized by usage and including nested tags
- expose full tag metadata from the graph helper for reuse and anchor linking
- restyle tag chips to scale font weight/size and show usage counts

## Testing
- bundle exec jekyll build --trace *(fails: `jekyll` executable missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f71e07388326a92e42cd620759bb)