### PR TITLE
Fit notes graph view to canvas

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -146,9 +146,11 @@
       };
 
       const initLayout = () => {
+        const width = graphCanvas.width / window.devicePixelRatio;
+        const height = graphCanvas.height / window.devicePixelRatio;
         nodes.forEach((n) => {
-          n.x = Math.random() * graphCanvas.width;
-          n.y = Math.random() * graphCanvas.height;
+          n.x = Math.random() * width;
+          n.y = Math.random() * height;
           n.vx = 0;
           n.vy = 0;
           n.mass = 1;
@@ -263,6 +265,41 @@
         centerOnNode(current, false, true);
       };
 
+      const fitToCanvas = () => {
+        const width = graphCanvas.width / window.devicePixelRatio;
+        const height = graphCanvas.height / window.devicePixelRatio;
+        if (!nodes.length || width === 0 || height === 0) return;
+
+        let minX = Infinity;
+        let maxX = -Infinity;
+        let minY = Infinity;
+        let maxY = -Infinity;
+        nodes.forEach((n) => {
+          minX = Math.min(minX, n.x);
+          maxX = Math.max(maxX, n.x);
+          minY = Math.min(minY, n.y);
+          maxY = Math.max(maxY, n.y);
+        });
+
+        const padding = Math.max(12, Math.min(width, height) * 0.04);
+        const contentWidth = Math.max(1, maxX - minX);
+        const contentHeight = Math.max(1, maxY - minY);
+        const paddedWidth = contentWidth + padding * 2;
+        const paddedHeight = contentHeight + padding * 2;
+
+        const scaleX = width / paddedWidth;
+        const scaleY = height / paddedHeight;
+        const fitScale = Math.min(scaleX, scaleY);
+        const targetScale = Math.max(options.minScale, Math.min(options.maxScale, fitScale));
+
+        const centerX = (minX + maxX) / 2;
+        const centerY = (minY + maxY) / 2;
+
+        camera.scale = targetScale;
+        camera.x = width / 2 - centerX * targetScale;
+        camera.y = height / 2 - centerY * targetScale;
+      };
+
       const resize = () => {
         const rect = graphWrapper.getBoundingClientRect();
         const maxHeight = Math.round(window.innerHeight * safeHeightFactor);
@@ -276,10 +313,12 @@
         camera.scale = options.defaultScale;
         if (options.layout === "radial") {
           layoutRadial();
+          fitToCanvas();
           centerOnCurrent();
         } else {
           initLayout();
           tick(60);
+          fitToCanvas();
           centerOnCurrent();
         }
         draw();


### PR DESCRIPTION
## Summary
- base random node placement on CSS pixel canvas size to avoid oversized coordinates
- add helper to fit graph bounds to canvas with padding and scale limits
- apply fitting after layout before centering so initial view uses full canvas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949fb4a607c8326b4bd098684844c47)