### PR TITLE
Emphasize category labels in notes graph

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -109,6 +109,27 @@
       return trimmed.endsWith("/") ? trimmed : trimmed + "/";
     };
 
+    const emphasizedCategories = new Set(["autism", "games", "rockhound", "rockhounding", "blog"]);
+
+    const isCategoryNode = (node) => {
+      if (!node) return false;
+      const category = (node.category || "").toLowerCase();
+      const label = (node.label || "").toLowerCase();
+      const normalizedPath = normalizePath(node.path || "").toLowerCase();
+
+      if (emphasizedCategories.has(category) || emphasizedCategories.has(label)) return true;
+
+      return Array.from(emphasizedCategories).some((root) => {
+        if (!root) return false;
+        const rootPath = `/${root}/`;
+        return (
+          normalizedPath === rootPath ||
+          normalizedPath.startsWith(`/notes/${root}/`) ||
+          normalizedPath.startsWith(rootPath)
+        );
+      });
+    };
+
     const isCurrentPath = (notePath) => {
       const current = normalizePath(window.location.pathname);
       const target = normalizePath(notePath);
@@ -533,9 +554,13 @@
         ctx.quadraticCurveTo(x, y, x + radius, y);
       };
 
-      const drawLabel = (text, screenX, screenY, isActive) => {
+      const boldFont = options.boldFont || `600 ${options.font}`;
+
+      const drawLabel = (text, screenX, screenY, isActive, emphasize) => {
         const paddingX = 8;
         const paddingY = 5;
+        const font = emphasize ? boldFont : options.font;
+        ctx.font = font;
         const metrics = ctx.measureText(text);
         const ascent = metrics.actualBoundingBoxAscent || 10;
         const descent = metrics.actualBoundingBoxDescent || 2;
@@ -624,7 +649,7 @@
             if (!label) return;
             const text = label.length > options.labelMax ? label.slice(0, options.labelMax - 3) + "..." : label;
             const screen = toScreen(n.x, n.y);
-            drawLabel(text, screen.x, screen.y, !!activeNode);
+            drawLabel(text, screen.x, screen.y, !!activeNode, options.emphasizeNode?.(n));
           });
         }
       };
@@ -773,6 +798,7 @@
       labelLimit: 140,
       labelMax: 30,
       font: "12px ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif",
+      emphasizeNode: isCategoryNode,
       centerOnCurrent: true,
       defaultScale: 2.0,
       minScale: 0.8,


### PR DESCRIPTION
## Summary
- add category detection for key graph nodes such as games, autism, rockhounding, and blog
- render labels for emphasized categories in bold to keep them visible on the graph

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949fe399d9c83269aa91df799c2684c)