### PR TITLE
Ensure graph pills fit weighted labels

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -136,6 +136,14 @@
 
     const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 
+    const boldFont = options.boldFont || `600 ${options.font}`;
+
+    const weightedFontForNode = (node) => {
+      const baseWeight = 460;
+      const weight = clamp(Math.round(baseWeight + (node.degree || 0) * 55), 460, 820);
+      return `${weight} ${options.font}`;
+    };
+
     const seasonForDate = (dateStr) => {
       if (!dateStr) return null;
       const m = dateStr.toString().trim().match(/(\\d{4})-(\\d{2})-(\\d{2})/);
@@ -246,9 +254,10 @@
 
       const measureNodes = () => {
         ctx.save();
-        ctx.font = options.font;
         nodes.forEach((n) => {
           const label = labelForNode(n);
+          const font = weightedFontForNode(n);
+          ctx.font = font;
           const metrics = ctx.measureText(label);
           const ascent = metrics.actualBoundingBoxAscent || 10;
           const descent = metrics.actualBoundingBoxDescent || 3;
@@ -725,14 +734,6 @@
         ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
         ctx.lineTo(x, y + radius);
         ctx.quadraticCurveTo(x, y, x + radius, y);
-      };
-
-      const boldFont = options.boldFont || `600 ${options.font}`;
-
-      const weightedFontForNode = (node) => {
-        const baseWeight = 460;
-        const weight = clamp(Math.round(baseWeight + (node.degree || 0) * 55), 460, 820);
-        return `${weight} ${options.font}`;
       };
 
       const drawLabel = (text, screenX, screenY, isActive, emphasize) => {


### PR DESCRIPTION
## Summary
- measure graph node pills using weighted font metrics so label backgrounds match the rendered text
- move weighted font helper earlier to reuse for measuring and drawing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a349bdcd483269670f50e19ab5428)