### PR TITLE
Fix notes graph fallbacks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,9 +13,6 @@ include:
   - "_pages"
   - "_admin"
 
-exclude:
-  - "_includes/notes_graph.json"
-
 use_html_extension: false
 open_external_links_in_new_tab: false
 embed_tweets: false

--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -47,7 +47,14 @@
     wrapper.dataset.graphInit = "true";
 
     const data = {% include notes_graph.json %};
-    const tagGraphData = { nodes: {{ tag_graph_nodes_json }}, edges: {{ tag_graph_edges_json }} };
+    const graphData = data && Array.isArray(data.nodes)
+      ? data
+      : { nodes: [], edges: [] };
+
+    const tagGraphData = {
+      nodes: {{ tag_graph_nodes_json }} || [],
+      edges: {{ tag_graph_edges_json }} || [],
+    };
 
     const readCssVar = (name, fallback) => {
       const root = getComputedStyle(document.documentElement);
@@ -1022,7 +1029,7 @@
       return node.category || "notes";
     };
 
-    buildGraph(wrapper, canvas, data, {
+    buildGraph(wrapper, canvas, graphData, {
       nodeRadius: 5,
       repulsion: 180,
       spring: 0.12,


### PR DESCRIPTION
## Summary
- ensure the notes graph script falls back to empty datasets when generated data is missing
- keep tag graph data from breaking rendering by defaulting missing JSON to arrays
- allow the generated notes_graph.json include to be processed during builds

## Testing
- not run (environment setup still installing bundle dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4bb299508326a919b82b8de6532b)